### PR TITLE
`library/*`: Use short form for target definitions

### DIFF
--- a/library/helloworld/Kraftfile
+++ b/library/helloworld/Kraftfile
@@ -5,15 +5,9 @@ name: helloworld
 unikraft: stable
 
 targets:
-- plat: qemu
-  arch: x86_64
-- plat: qemu
-  arch: arm64
-- plat: fc
-  arch: x86_64
-- plat: xen
-  arch: x86_64
-- plat: linuxu
-  arch: x86_64
-- plat: linuxu
-  arch: arm64
+- qemu/x86_64
+- qemu/arm64
+- fc/x86_64
+- xen/x86_64
+- linuxu/x86_64
+- linuxu/arm64

--- a/library/nginx1.15/Kraftfile
+++ b/library/nginx1.15/Kraftfile
@@ -38,14 +38,10 @@ unikraft:
     CONFIG_VIRTIO_PCI: 'y'
 
 targets:
-- plat: qemu
-  arch: x86_64
-- plat: qemu
-  arch: arm64
-- plat: fc
-  arch: x86_64
-- plat: fc
-  arch: arm64
+- qemu/x86_64
+- qemu/arm64
+- fc/x86_64
+- fc/arm64
 
 libraries:
   musl: staging

--- a/library/python3.10/Kraftfile
+++ b/library/python3.10/Kraftfile
@@ -33,19 +33,14 @@ unikraft:
     CONFIG_STACK_SIZE_PAGE_ORDER: 10
     CONFIG_UKSYSINFO: 'y'
     CONFIG_VIRTIO_PCI: 'y'
+    CONFIG_KVM_PCI: 'y'
     # Debug options
     # CONFIG_LIBUKDEBUG_PRINTD: 'y'
     # CONFIG_LIBUKDEBUG_PRINTK_INFO: 'y'
 
 targets:
-- plat: qemu
-  arch: x86_64
-  kconfig:
-    CONFIG_KVM_PCI: 'y'
-- plat: fc
-  arch: x86_64
-  kconfig:
-    CONFIG_KVM_PCI: 'y'
+- qemu/x86_64
+- fc/x86_64
 
 libraries:
   musl: staging


### PR DESCRIPTION
There are currently two ways to specify the platform and architecture in `Kraftfile`s with rules to build / run targets:

a)

```
- plat: qemu
  arch: arm64
```

b)

```
- qemu/arm64
```

For simplicity and conciseness, go for option b) in all `Kraftfile`s that specify targets.