### PR TITLE
fix(merge-oci-digests): Show `--all` packages

### DIFF
--- a/.github/actions/merge-oci-digests/action.yaml
+++ b/.github/actions/merge-oci-digests/action.yaml
@@ -35,5 +35,5 @@ runs:
       STAGING_RELEASE=$(curl https://api.github.com/repos/unikraft/kraftkit/releases | jq -r 'map(select(.prerelease)) | first | .tag_name');
       wget https://github.com/unikraft/kraftkit/releases/download/${STAGING_RELEASE}/kraftkit_${STAGING_RELEASE:1}_linux_amd64.deb;
       sudo dpkg -i kraftkit_${STAGING_RELEASE:1}_linux_amd64.deb;
-      kraft pkg ls --apps;
+      kraft pkg ls --apps --all;
       kraft pkg push ${{ inputs.name }};


### PR DESCRIPTION
Following the merge of kraftkit#945, without specifying the `--all` flag, the host architecture and platform are detected and used to reduce the output.  In this CI/CD context, we wish to show all variants which requires the use of this flag.  Without this flag, the GitHub Actions workflow fails as it cannot determine the host platform.

