### PR TITLE
fix(library): Update Nginx config

### DIFF
--- a/library/nginx/1.15/rootfs/nginx/conf/nginx.conf
+++ b/library/nginx/1.15/rootfs/nginx/conf/nginx.conf
@@ -10,7 +10,6 @@ events {
 
 http {
   include mime.types;
-  access_log /dev/stdout;
   default_type application/octet-stream;
 
   keepalive_timeout 65;


### PR DESCRIPTION
Update Nginx config file to not use `/dev/stdout`, since Unikraft does not properly support it yet.