### PR TITLE
feat(examples): Introduce HTTP Tokio example

### DIFF
--- a/examples/http-rust1.75-tokio/Cargo.toml
+++ b/examples/http-rust1.75-tokio/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "http-tokio"
+version = "0.1.0"
+edition = "2021"
+
+
+[dependencies]
+tokio = {version = "1",  features = ["rt-multi-thread", "net", "time", "macros", "io-util"] }

--- a/examples/http-rust1.75-tokio/Dockerfile
+++ b/examples/http-rust1.75-tokio/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:1.75.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./src /src/src
+COPY ./Cargo.toml /src/Cargo.toml
+
+RUN cargo build
+
+FROM scratch
+
+COPY --from=build src/target/debug/http-tokio /server
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2

--- a/examples/http-rust1.75-tokio/Kraftfile
+++ b/examples/http-rust1.75-tokio/Kraftfile
@@ -1,0 +1,11 @@
+spec: v0.6
+
+runtime: unikraft.org/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/server"]
+
+targets:
+- qemu/x86_64
+- fc/x86_64

--- a/examples/http-rust1.75-tokio/README.md
+++ b/examples/http-rust1.75-tokio/README.md
@@ -1,0 +1,31 @@
+# Simple HTTP `Tokio` Server
+
+This is a simple HTTP server written in [Rust](https://www.rust-lang.org/) using the [`Tokio` runtime](https://tokio.rs/).
+To run this example, first [install the `kraft` command-line tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+Make sure you have the [`BuildKit`](https://docs.docker.com/build/buildkit/) container started:
+
+```console
+docker run -d --name buildkitd --privileged moby/buildkit:latest
+export KRAFTKIT_BUILDKIT_HOST=docker-container://buildkitd
+```
+
+Then run:
+
+```console
+kraft run --plat qemu --arch x86_64 -p 8080:8080 -M 128M .
+```
+
+Query the server using:
+
+```console
+curl localhost:8080
+```
+
+You will get a `Hello, World!` message.
+
+## Learn More
+
+- [Unikraft Documentation](https://unikraft.org/docs/cli)
+- [How to build `Dockerfile` root filesystems with `BuildKit`](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/examples/http-rust1.75-tokio/src/main.rs
+++ b/examples/http-rust1.75-tokio/src/main.rs
@@ -1,0 +1,27 @@
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
+    let listener = TcpListener::bind(&addr).await?;
+
+    println!("Listening on: http://{}", addr);
+
+    loop {
+        let (mut stream, _) = listener.accept().await?;
+
+        tokio::spawn(async move {
+            loop {
+                let mut buffer = [0; 1024];
+                let _ = stream.read(&mut buffer).await;
+
+                let contents = "Hello, World!\r\n";
+                let content_length = contents.len();
+                let response = format!("HTTP/1.1 200 OK\r\nContent-Length: {content_length}\r\n\r\n{contents}");
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+    }
+}


### PR DESCRIPTION
Introduce a simple HTTP server written in Rust using the Tokio framework.