### PR TITLE
docs(redis/7.0): Indicate min memory requirement

### DIFF
--- a/library/redis/7.0/README.md
+++ b/library/redis/7.0/README.md
@@ -2,10 +2,19 @@
 
 This directory contains the definition for the `unikraft.org/redis:7.0` image.
 
-To run this image, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli) and then you can run:
+Before you run image, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli).
+
+To build and run image locally:
 
 ```
-kraft run -p 6379:6379 unikraft.org/redis:7.0
+kraft build
+kraft run -p 6379:6379 -M 128M
+```
+
+To fetch and run prebuilt image:
+
+```
+kraft run -p 6379:6379 unikraft.org/redis:7.0 -M 128M
 ```
 
 Once executed you will be able to view connect with the Redis client:


### PR DESCRIPTION
Minimal memory size is 128M
Also update the readme to include build the image locally