### PR TITLE
feat(examples): Introduce simple Python HTTP server

### DIFF
--- a/examples/http-python3.12/.dockerignore
+++ b/examples/http-python3.12/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/http-python3.12/.gitignore
+++ b/examples/http-python3.12/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/http-python3.12/Dockerfile
+++ b/examples/http-python3.12/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+
+COPY ./server.py /app/server.py

--- a/examples/http-python3.12/Kraftfile
+++ b/examples/http-python3.12/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: http-python
+
+runtime: python:3.12
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/python3", "/app/server.py"]

--- a/examples/http-python3.12/README.md
+++ b/examples/http-python3.12/README.md
@@ -1,0 +1,47 @@
+# Simple Python HTTP Server
+
+This directory contains a simple [Python](https://www.python.org/) HTTP server.
+The image opens up a simple HTTP server and provides a simple response to each request.
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run -M 512M -p 8080:8080 --plat qemu --arch x86_64
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it default to the CPU architecture of your system.
+
+Once executed, it will open port `8080` and wait for connections, and it can be queried.
+
+Query the Unikraft instance using:
+
+```bash
+curl localhost:8080
+```
+
+It will print a "Hello, World!" message.
+
+You can list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+```text
+NAME           KERNEL                          ARGS                             CREATED         STATUS   MEM   PLAT
+musing_julius  oci://unikraft.org/python:3.12  /usr/bin/python3 /app/server.py  10 minutes ago  running  0MiB  qemu/x86_64
+```
+
+The instance name is `musing_julius`.
+To close the Unikraft instance, use:
+
+```bash
+kraft rm musing_julius
+```
+
+Note that closing the `kraft run` command (such as using `Ctrl+c`) does not close the Unikraft instance.
+If you want the Unikraft instance closed when closing the `kraft run` command, use the `--rm` option:
+
+```bash
+kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64
+```

--- a/examples/http-python3.12/server.py
+++ b/examples/http-python3.12/server.py
@@ -1,0 +1,41 @@
+"""
+Simple HTTP server
+
+Serves a simple "Hello, World!" string as response to basic HTTP GET requests.
+"""
+
+import argparse
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class MyServer(BaseHTTPRequestHandler):
+    """HTTP Server class"""
+    def do_GET(self):
+        """Reply with a simple message to HTTP GET requests."""
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write(bytes("Hello, World!\n", "utf-8"))
+
+def parse_args():
+    """Parse command line arguments, if provided."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8080)
+    return parser.parse_args()
+
+def main(args):
+    """Start HTTP server and wait for connections."""
+    server = HTTPServer((args.host, args.port), MyServer)
+
+    print(f"starting server at {args.host}:{args.port}")
+
+    try:
+        server.serve_forever()
+
+    except KeyboardInterrupt:
+        pass
+
+    print("server stopped")
+
+if __name__ == "__main__":
+    main(parse_args())


### PR DESCRIPTION
Introduce example for a simple Python HTTP server. It uses the `python:3.12` image (binary-compatible).

Add:

* `Kraftfile`: build / run rules, including pulling the `python` image
* `Dockerfile`: application filesystem (just copies `server.py`)
* `README.md`: document how to use
* `server.py`: the actual Python HTTP server implementation