### PR TITLE
fix(examples): Improve README for http-python3.10

### DIFF
--- a/examples/http-python3.10/README.md
+++ b/examples/http-python3.10/README.md
@@ -1,19 +1,61 @@
-# Python 3.10 Web Server on Unikraft
+# Simple Python HTTP Server
 
-This directory contains an example Python3 HTTP server.
+This directory contains a simple [Python](https://www.python.org/) HTTP server running on Unikraft.
+It opens a Unikraft instance sunning simple HTTP server that provides a simple response to each request.
+
+## Set Up
 
 To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli).
+Then, clone this repository and `cd` into this directory.
 
-Then, clone this repository and cd into this directory.
-You can then start the Python3 HTTP server Unikraft unikernel via:
+## Run and Use
 
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run -p 8080:8080 --plat qemu --arch x86_64
 ```
-kraft run -p 8080:8080 -M 256Mi .
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it default to the CPU architecture of your system.
+
+Once executed, it will open port `8080` and wait for connections, and it can be queried.
+
+Query the Unikraft instance using:
+
+```bash
+curl localhost:8080
 ```
 
-Once executed you will be able to view the welcome page at http://localhost:8080.
+It will print a "Hello, World!" message.
 
-## Learn more
+## Inspect and Close
+
+You can list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+```text
+NAME                 KERNEL                          ARGS        CREATED         STATUS   MEM   PLAT
+nostalgic_snowflake  oci://unikraft.org/python:3.10  /server.py  46 seconds ago  running  0MiB  qemu/x86_64
+```
+
+The instance name is `nostalgic_snowflake`.
+To close the Unikraft instance, use:
+
+```bash
+kraft rm nostalgic_snowflake
+```
+
+Note that closing the `kraft run` command (such as using `Ctrl+c`) does not close the Unikraft instance.
+If you want the Unikraft instance closed when closing the `kraft run` command, use the `--rm` option:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64
+```
+
+## Learn More
 
 - [How to run unikernels locally](https://unikraft.org/docs/cli/running)
 - [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)


### PR DESCRIPTION
Improve `README.md` for `http-python3.10` to feature full instructions on running, using, inspecting and closing a Unikraft instance.