### PR TITLE
fix(examples): Improve http-python3.10 README

### DIFF
--- a/examples/http-python3.10/README.md
+++ b/examples/http-python3.10/README.md
@@ -11,13 +11,13 @@ To run this example, [install Unikraft's companion command-line toolchain `kraft
 Use `kraft` to run the image and start a Unikraft instance:
 
 ```bash
-kraft run -p 8080:8080 --plat qemu --arch x86_64
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64
 ```
 
 If the `--plat` argument is left out, it defaults to `qemu`.
 If the `--arch` argument is left out, it defaults to your system's CPU architecture.
 
-Once executed, it will open port `8080` and wait for connections. 
+Once executed, it will open port `8080` and wait for connections.
 To test it, you can use `curl`:
 
 ```bash
@@ -39,32 +39,25 @@ nostalgic_snowflake  oci://unikraft.org/python:3.10  /server.py  46 seconds ago 
 ```
 
 The instance name is `nostalgic_snowflake`.
-To close the Unikraft instance, use:
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
 
 ```bash
 kraft rm nostalgic_snowflake
 ```
 
-Note that closing the `kraft run` command (e.g., via `Ctrl+c`) does not kill the Unikraft instance.
-If you want the Unikraft instance closed when closing the `kraft run` command, use the `--rm` option:
-
-```bash
-kraft run --rm -p 8080:8080 --plat qemu --arch x86_64
-```
-
-Finally, note that depending on how you modify this example your instance **may** need more memory to run.
+Note that depending on how you modify this example your instance **may** need more memory to run.
 To do so, use the `kraft run`'s `-M` flag, for example:
 
 ```bash
 kraft run -p 8080:8080 --plat qemu --arch x86_64 -M 512M
 ```
 
-## kraft and sudo
+## `kraft` and `sudo`
 
-Mixing invocations of kraft and sudo can lead to unexpected behavior. 
-Read more about how to start kraft without sudo at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
 
 ## Learn More
 
 - [How to run unikernels locally](https://unikraft.org/docs/cli/running)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/docs/getting-started/integrations/buildkit)


### PR DESCRIPTION
Improve `README.md` of `http-python3.10` example:

* Remove trailing whitespaces.
* Use `--rm` option to `kraft run` by default.
* Update broken link referencing `BuildKit`.
* Use backticks for "command formatting" for `kraft` and `sudo`.