### PR TITLE
.github/workflows: Add option to start workflows remotely

### DIFF
--- a/.github/workflows/library-base.yaml
+++ b/.github/workflows/library-base.yaml
@@ -1,6 +1,9 @@
 name: library/base:latest
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-caddy2.7.yaml
+++ b/.github/workflows/library-caddy2.7.yaml
@@ -1,6 +1,9 @@
 name: library/caddy2.7
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-helloworld.yaml
+++ b/.github/workflows/library-helloworld.yaml
@@ -1,6 +1,9 @@
 name: library/helloworld:latest
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-hugo0.122.yaml
+++ b/.github/workflows/library-hugo0.122.yaml
@@ -1,6 +1,9 @@
 name: library/hugo:0.122
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-lua5.4.4.yaml
+++ b/.github/workflows/library-lua5.4.4.yaml
@@ -1,6 +1,9 @@
 name: library/lua5.4.4
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-lua5.4.yaml
+++ b/.github/workflows/library-lua5.4.yaml
@@ -1,6 +1,9 @@
 name: library/lua:5.4
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-memcached1.6.yaml
+++ b/.github/workflows/library-memcached1.6.yaml
@@ -1,6 +1,9 @@
 name: library/memcached:1.6
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-nginx1.15.yaml
+++ b/.github/workflows/library-nginx1.15.yaml
@@ -1,6 +1,9 @@
 name: library/nginx:1.15
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-nginx1.25.yaml
+++ b/.github/workflows/library-nginx1.25.yaml
@@ -1,6 +1,9 @@
 name: library/nginx1.25
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-node18.yaml
+++ b/.github/workflows/library-node18.yaml
@@ -1,6 +1,9 @@
 name: library/node:18
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-node20.yaml
+++ b/.github/workflows/library-node20.yaml
@@ -1,6 +1,9 @@
 name: library/node:20
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   schedule:
   - cron: '0 0 * * *' # Everyday at 12AM
 

--- a/.github/workflows/library-node21.yaml
+++ b/.github/workflows/library-node21.yaml
@@ -1,6 +1,9 @@
 name: library/node:21
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-perl5.38.yaml
+++ b/.github/workflows/library-perl5.38.yaml
@@ -1,6 +1,9 @@
 name: library/perl5.38
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-php8.2.yaml
+++ b/.github/workflows/library-php8.2.yaml
@@ -1,6 +1,9 @@
 name: library/php8.2
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-python3.10.yaml
+++ b/.github/workflows/library-python3.10.yaml
@@ -1,6 +1,9 @@
 name: library/python:3.10
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-python3.12.yaml
+++ b/.github/workflows/library-python3.12.yaml
@@ -1,6 +1,9 @@
 name: library/python3.12
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-redis7.0.yaml
+++ b/.github/workflows/library-redis7.0.yaml
@@ -1,6 +1,9 @@
 name: library/redis:7.0
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-redis7.2.yaml
+++ b/.github/workflows/library-redis7.2.yaml
@@ -1,6 +1,9 @@
 name: library/redis7.2
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-ruby3.2.yaml
+++ b/.github/workflows/library-ruby3.2.yaml
@@ -1,6 +1,9 @@
 name: library/ruby3.2
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-skipper0.18.yaml
+++ b/.github/workflows/library-skipper0.18.yaml
@@ -1,6 +1,9 @@
 name: library/skipper0.18
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/library-sqlite3.40.yaml
+++ b/.github/workflows/library-sqlite3.40.yaml
@@ -1,6 +1,9 @@
 name: library/sqlite:3.40
 
 on:
+  repository_dispatch:
+    types: [core_merge]
+
   workflow_dispatch:
 
   schedule:


### PR DESCRIPTION
This will allow the core to trigger these workflows to do additional checks before merging to stable.