### PR TITLE
fix(library): Assign minimum memory to fix crash #110

### DIFF
--- a/library/python/3.10/README.md
+++ b/library/python/3.10/README.md
@@ -5,7 +5,7 @@ This directory contains the definition for the `unikraft.org/python:3.10` image.
 To run this image, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli) and then you can run:
 
 ```
-kraft run unikraft.org/python:3.10
+kraft run -M 256M unikraft.org/python:3.10
 ```
 
 ## See also

--- a/library/python/3.12/README.md
+++ b/library/python/3.12/README.md
@@ -5,7 +5,7 @@ This directory contains the definition for the `unikraft.org/python:3.12` image 
 To run this image, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli) and then you can run:
 
 ```console
-kraft run -p 8080:8080 unikraft.org/python:3.12
+kraft run -p 8080:8080 -M 256M unikraft.org/python:3.12
 ```
 
 Query the server using:


### PR DESCRIPTION
The documentation for the `python:3.12` application doesn't specify a `-M` flag in the run command. As a result, There isn't enough memory to successfully run the application.

A minimum memory of 256M works well. Without this, the application crashes.