### PR TITLE
fix(library): Use memory argument to run Python

### DIFF
--- a/library/python/3.10/README.md
+++ b/library/python/3.10/README.md
@@ -5,7 +5,7 @@ This directory contains the definition for the `unikraft.org/python:3.10` image.
 To run this image, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli) and then you can run:
 
 ```
-kraft run unikraft.org/python:3.10
+kraft run -M 512M unikraft.org/python:3.10
 ```
 
 ## See also

--- a/library/python/3.12/README.md
+++ b/library/python/3.12/README.md
@@ -5,7 +5,7 @@ This directory contains the definition for the `unikraft.org/python:3.12` image 
 To run this image, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli) and then you can run:
 
 ```console
-kraft run -p 8080:8080 unikraft.org/python:3.12
+kraft run -p 8080:8080 -M 512M unikraft.org/python:3.12
 ```
 
 Query the server using:


### PR DESCRIPTION
The current `kraft run` command doesn't feature the `-M` option to pass the required amount of memory for the Python 3.12 build. Because of that, using `kraft run` doesn't work.

Update the command to feature `-M 512M`, i.e. enough memory to run Python.