### PR TITLE
refactor: Deprecate `linuxu` target

### DIFF
--- a/.github/workflows/library-helloworld.yaml
+++ b/.github/workflows/library-helloworld.yaml
@@ -32,10 +32,6 @@ jobs:
           arch: x86_64
         - plat: xen
           arch: x86_64
-        - plat: linuxu
-          arch: x86_64
-        - plat: linuxu
-          arch: arm64
 
     runs-on: ubuntu-latest
 

--- a/library/helloworld/Kraftfile
+++ b/library/helloworld/Kraftfile
@@ -9,5 +9,3 @@ targets:
 - qemu/arm64
 - fc/x86_64
 - xen/x86_64
-- linuxu/x86_64
-- linuxu/arm64

--- a/native/helloworld-c/Kraftfile
+++ b/native/helloworld-c/Kraftfile
@@ -7,7 +7,6 @@ unikraft: stable
 targets:
 - fc/arm64
 - fc/x86_64
-- linuxu/x86_64
 - qemu/arm64
 - qemu/x86_64
 - xen/x86_64

--- a/native/helloworld-cpp/Kraftfile
+++ b/native/helloworld-cpp/Kraftfile
@@ -9,7 +9,6 @@ unikraft:
     CONFIG_LIBUKSIGNAL: y
 
 targets:
-- linuxu/x86_64
 - qemu/x86_64
 - xen/x86_64
 - qemu/arm64

--- a/native/http-c/Kraftfile
+++ b/native/http-c/Kraftfile
@@ -14,8 +14,6 @@ targets:
 - qemu/arm64
 - fc/x86_64
 - xen/x86_64
-- linuxu/x86_64
-- linuxu/arm64
 
 libraries:
   lwip:


### PR DESCRIPTION
Following the decision in the Unikraft OSS Project's community, the linuxu target is has been deprecated.  This was actualized in the Unikraft Core repository in https://github.com/unikraft/unikraft/pull/1422

Signed-off-by: Alexander Jung <alex@unikraft.io>
