### PR TITLE
fix(base): Remove `CONFIG_LWIP_FAILNOIFACE`

### DIFF
--- a/library/base/Kraftfile
+++ b/library/base/Kraftfile
@@ -126,8 +126,6 @@ libraries:
       CONFIG_LWIP_LOOPIF: 'y'
       CONFIG_LWIP_UKNETDEV: 'y'
       CONFIG_LWIP_LOOPBACK: 'y'
-      # Fail booting without network interface
-      CONFIG_LWIP_FAILNOIFACE: 'y'
       CONFIG_LWIP_TCP: 'y'
       CONFIG_LWIP_UDP: 'y'
       CONFIG_LWIP_RAW: 'y'


### PR DESCRIPTION
The option `CONFIG_LWIP_FAILNOIFACE` makes sense to enable only for applications that rely on networking. Where networking is optional, this KConfig option should be set to `n` and where no networking is needed, we ideally want to build a Unikernel without networking capabilities and drivers. The `base` image is a generic elfloader image where we are weakening the specialization degree because we need to think a bit more "general purpose": Applications without networking requirements should be able to be run as well.

Github-Fixes: #135