### PR TITLE
fix(tests): Modify faulty Kraftfile

### DIFF
--- a/tests/synthetic/dir/Kraftfile
+++ b/tests/synthetic/dir/Kraftfile
@@ -4,4 +4,4 @@ runtime: base:latest
 
 rootfs: ./Dockerfile
 
-cmd: ["python2 threading-demo.py"]
+cmd: ["/dir"]


### PR DESCRIPTION
Fixed the `tests/synthetic/dir/Kraftfile` so that the test can run as expected.