### PR TITLE
fix(README): Correct SurrealDB version from 11.2 to 1.1 (#154)

### DIFF
--- a/library/surreal/1.1/README.md
+++ b/library/surreal/1.1/README.md
@@ -8,7 +8,7 @@ It implements a simple HTTP server running on Unikraft that provides a simple re
 Use `kraft` to run the image and start a Unikraft instance:
 
 ```bash
-kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 unikraft.org/surreal:11.2
+kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 unikraft.org/surreal:1.1
 ```
 
 If the `--plat` argument is left out, it defaults to `qemu`.


### PR DESCRIPTION
The README incorrectly listed SurrealDB version as 11.2, but the available version in `kraft pkg ls` is 1.1. Updated the command to use the correct version. Fixes #154