### PR TITLE
Add bincompat curl test app using static binary

### DIFF
--- a/tests/curl_bincompat/Makefile
+++ b/tests/curl_bincompat/Makefile
@@ -1,0 +1,1 @@
+UK_APP := curl_bincompat

--- a/tests/curl_bincompat/run.sh
+++ b/tests/curl_bincompat/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+./curl --version


### PR DESCRIPTION
This PR adds a bincompat test application for curl using the statically compiled binary from moparisthebest/static-curl.

- The `curl` binary is placed under `tests/curl_bincompat/`
- Includes a simple `run.sh` script to test curl functionality
- Minimal Makefile added for compatibility with the test catalog

This follows the Unikraft recommendation of starting with bincompat before native porting. Kindly review and suggest improvements if needed.
