### PR TITLE
Failed Caddy runtime switch

### DIFF
--- a/examples/caddy-base/.dockerignore
+++ b/examples/caddy-base/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/caddy-base/.gitignore
+++ b/examples/caddy-base/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/caddy-base/Caddyfile
+++ b/examples/caddy-base/Caddyfile
@@ -1,0 +1,3 @@
+:2015
+
+respond "Hello, World!"

--- a/examples/caddy-base/Dockerfile
+++ b/examples/caddy-base/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.21.3-bookworm AS build
+
+ARG CADDY_VERSION=2.7.5
+
+WORKDIR /caddy
+
+RUN --mount=type=cache,target=/root/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    set -xe; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        git \
+        ca-certificates; \
+    git clone --depth=1 --branch v${CADDY_VERSION} https://github.com/caddyserver/caddy.git /caddy; \
+    go build -v \
+        -buildmode=pie \
+        -ldflags "-linkmode external -extldflags -static-pie" \
+        -tags netgo \
+        -o /caddy/caddy cmd/caddy/main.go;
+
+RUN echo "127.0.0.1 localhost" > /tmp/hosts
+
+FROM scratch
+
+COPY --from=build /caddy/caddy /usr/bin/caddy
+COPY --from=build /tmp/hosts /etc/hosts
+COPY ./Caddyfile /etc/caddy/Caddyfile

--- a/examples/caddy-base/Kraftfile
+++ b/examples/caddy-base/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: caddy-base
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/examples/caddy-base/README.md
+++ b/examples/caddy-base/README.md
@@ -1,0 +1,64 @@
+# Caddy
+
+This directory contains a [`Caddy`](https://caddyserver.com/) web server running on Unikraft.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 2015:2015 --plat qemu --arch x86_64 -M 256M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `2015` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:2015
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME              KERNEL                        ARGS                                              CREATED        STATUS   MEM   PORTS                   PLAT
+vigilant_michael  oci://unikraft.org/caddy:2.7  /usr/bin/caddy run --config /etc/caddy/Caddyfile  6 seconds ago  running  244M  0.0.0.0:2015->2015/tcp  qemu/x86_64
+```
+
+The instance name is `vigilant_michael`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm vigilant_michael
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 2015:2015 --plat qemu --arch x86_64 -M 512M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/caddy-base/rootfs/etc/caddy/Caddyfile
+++ b/examples/caddy-base/rootfs/etc/caddy/Caddyfile
@@ -1,0 +1,9 @@
+:2015
+
+root * /var/www
+
+encode gzip
+
+templates
+
+file_server

--- a/examples/caddy-base/rootfs/var/www/index.html
+++ b/examples/caddy-base/rootfs/var/www/index.html
@@ -1,0 +1,1 @@
+Bye, World!


### PR DESCRIPTION
I have tried to switch the caddy example from caddy:2.7 to base:latest, but it says that the executable is not position-indemendent.