### PR TITLE
Add GitHub Actions workflow to test dragonfly:1.14 runtime

### DIFF
--- a/.github/workflows/library-dragonfly1.14.yaml
+++ b/.github/workflows/library-dragonfly1.14.yaml
@@ -76,6 +76,7 @@ jobs:
         with:
           working-directory: library/dragonfly/1.14
           run: |
+            sudo apt-get update -y && sudo apt-get install -y redis-tools
             set -xe
             kraft run --rm -p 6379:6379 --plat qemu --arch x86_64 -M 256M --no-pull index.unikraft.io/unikraft.org/dragonfly:1.14 &
             sleep 10

--- a/.github/workflows/library-dragonfly1.14.yaml
+++ b/.github/workflows/library-dragonfly1.14.yaml
@@ -2,24 +2,23 @@ name: library/dragonfly:1.14
 
 on:
   schedule:
-  - cron: '0 0 * * *' # Everyday at 12AM
+    - cron: '0 0 * * *' # Everyday at 12AM
 
   push:
     branches: [main]
     paths:
-    - 'library/dragonfly/1.14/**'
-    - '.github/workflows/library-dragonfly1.14.yaml'
-    - '!library/dragonfly/1.14/README.md'
+      - 'library/dragonfly/1.14/**'
+      - '.github/workflows/library-dragonfly1.14.yaml'
+      - '!library/dragonfly/1.14/README.md'
 
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
     paths:
-    - 'library/dragonfly/1.14/**'
-    - '.github/workflows/library-dragonfly1.14.yaml'
-    - '!library/dragonfly/1.14/README.md'
+      - 'library/dragonfly/1.14/**'
+      - '.github/workflows/library-dragonfly1.14.yaml'
+      - '!library/dragonfly/1.14/README.md'
 
-# Automatically cancel in-progress actions on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -30,51 +29,75 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - plat: qemu
-          arch: x86_64
-        - plat: fc
-          arch: x86_64
+          - plat: qemu
+            arch: x86_64
+          - plat: fc
+            arch: x86_64
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Build dragonfly1.14
-      uses: unikraft/kraftkit@staging
-      with:
-        loglevel: debug
-        workdir: library/dragonfly/1.14
-        runtimedir: /github/workspace/.kraftkit
-        plat: ${{ matrix.plat }}
-        arch: ${{ matrix.arch }}
-        push: false
-        output: oci://index.unikraft.io/unikraft.org/dragonfly:1.14
+      - name: Build dragonfly1.14
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          workdir: library/dragonfly/1.14
+          runtimedir: /github/workspace/.kraftkit
+          plat: ${{ matrix.plat }}
+          arch: ${{ matrix.arch }}
+          push: false
+          output: oci://index.unikraft.io/unikraft.org/dragonfly:1.14
 
-    - name: Archive OCI digests
-      uses: actions/upload-artifact@v4
-      with:
-        name: oci-digests-${{ matrix.arch }}-${{ matrix.plat }}
-        path: ${{ github.workspace }}/.kraftkit/oci/digests
-        if-no-files-found: error
+      - name: Archive OCI digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: oci-digests-${{ matrix.arch }}-${{ matrix.plat }}
+          path: ${{ github.workspace }}/.kraftkit/oci/digests
+          if-no-files-found: error
+
+  test:
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          curl -fsSL https://get.kraft.sh | sh
+          echo "$HOME/.unikraft/bin" >> $GITHUB_PATH
+
+      - name: Setup dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential qemu-system-x86 redis-tools
+
+      - name: Run Dragonfly with QEMU and test with redis-cli
+        working-directory: library/dragonfly/1.14
+        run: |
+          kraft run --rm -p 6379:6379 --plat qemu --arch x86_64 -M 256M unikraft.org/dragonfly:1.14 &
+          sleep 10
+          redis-cli -h 127.0.0.1 -p 6379 ping | grep PONG || (echo "Dragonfly did not respond correctly." && exit 1)
 
   push:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [ build ]
+    needs: [build, test]
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Login to OCI registry
-      uses: docker/login-action@v3
-      with:
-        registry: index.unikraft.io
-        username: ${{ secrets.REG_USERNAME }}
-        password: ${{ secrets.REG_TOKEN }}
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
 
-    - name: Retrieve, merge and push OCI digests
-      uses: ./.github/actions/merge-oci-digests
-      with:
-        name: index.unikraft.io/unikraft.org/dragonfly:1.14
-        push: true
+      - name: Retrieve, merge and push OCI digests
+        uses: ./.github/actions/merge-oci-digests
+        with:
+          name: index.unikraft.io/unikraft.org/dragonfly:1.14
+          push: true

--- a/.github/workflows/library-dragonfly1.14.yaml
+++ b/.github/workflows/library-dragonfly1.14.yaml
@@ -66,11 +66,12 @@ jobs:
     - name: Run Dragonfly with QEMU and test with redis-cli
       uses: unikraft/kraftkit@staging
       working-directory: library/dragonfly/1.14
-      run: |
-        set -xe
-        kraft run --rm -p 6379:6379 --plat qemu --arch x86_64 -M 256M unikraft.org/dragonfly:1.14 &
-        sleep 10
-        redis-cli -h 127.0.0.1 -p 6379 ping | grep PONG || (echo "Dragonfly did not respond correctly." && exit 1)
+      with:
+        run: |
+          set -xe
+          kraft run --rm -p 6379:6379 --plat qemu --arch x86_64 -M 256M unikraft.org/dragonfly:1.14 &
+          sleep 10
+          redis-cli -h 127.0.0.1 -p 6379 ping | grep PONG || (echo "Dragonfly did not respond correctly." && exit 1)
 
   push:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}

--- a/.github/workflows/library-dragonfly1.14.yaml
+++ b/.github/workflows/library-dragonfly1.14.yaml
@@ -79,7 +79,7 @@ jobs:
             sudo apt-get update -y && sudo apt-get install -y redis-tools
             set -xe
             kraft run --rm -p 6379:6379 --plat qemu --arch x86_64 -M 256M --no-pull index.unikraft.io/unikraft.org/dragonfly:1.14 &
-            sleep 10
+            sleep 30
             redis-cli -h 127.0.0.1 -p 6379 ping | grep PONG || (echo "Dragonfly did not respond correctly." && exit 1)
 
   push:

--- a/.github/workflows/library-dragonfly1.14.yaml
+++ b/.github/workflows/library-dragonfly1.14.yaml
@@ -73,8 +73,8 @@ jobs:
 
       - name: Run Dragonfly with QEMU and test with redis-cli
         uses: unikraft/kraftkit@staging
-        working-directory: library/dragonfly/1.14
         with:
+          working-directory: library/dragonfly/1.14
           run: |
             set -xe
             kraft run --rm -p 6379:6379 --plat qemu --arch x86_64 -M 256M --no-pull index.unikraft.io/unikraft.org/dragonfly:1.14 &

--- a/.github/workflows/library-dragonfly1.14.yaml
+++ b/.github/workflows/library-dragonfly1.14.yaml
@@ -1,23 +1,24 @@
+
 name: library/dragonfly:1.14
 
 on:
   schedule:
-  - cron: '0 0 * * *' # Everyday at 12AM
+    - cron: '0 0 * * *' # Everyday at 12AM
 
   push:
     branches: [main]
     paths:
-    - 'library/dragonfly/1.14/**'
-    - '.github/workflows/library-dragonfly1.14.yaml'
-    - '!library/dragonfly/1.14/README.md'
+      - 'library/dragonfly/1.14/'
+      - '.github/workflows/library-dragonfly1.14.yaml'
+      - '!library/dragonfly/1.14/README.md'
 
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
     paths:
-    - 'library/dragonfly/1.14/**'
-    - '.github/workflows/library-dragonfly1.14.yaml'
-    - '!library/dragonfly/1.14/README.md'
+      - 'library/dragonfly/1.14/'
+      - '.github/workflows/library-dragonfly1.14.yaml'
+      - '!library/dragonfly/1.14/README.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
@@ -29,49 +30,56 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - plat: qemu
-          arch: x86_64
-        - plat: fc
-          arch: x86_64
+          - plat: qemu
+            arch: x86_64
+          - plat: fc
+            arch: x86_64
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Build dragonfly1.14
-      uses: unikraft/kraftkit@staging
-      with:
-        loglevel: debug
-        workdir: library/dragonfly/1.14
-        runtimedir: /github/workspace/.kraftkit
-        plat: ${{ matrix.plat }}
-        arch: ${{ matrix.arch }}
-        push: false
-        output: oci://index.unikraft.io/unikraft.org/dragonfly:1.14
+      - name: Build dragonfly1.14
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          workdir: library/dragonfly/1.14
+          runtimedir: /github/workspace/.kraftkit
+          plat: ${{ matrix.plat }}
+          arch: ${{ matrix.arch }}
+          push: false
+          output: oci://index.unikraft.io/unikraft.org/dragonfly:1.14
 
-    - name: Archive OCI digests
-      uses: actions/upload-artifact@v4
-      with:
-        name: oci-digests-${{ matrix.arch }}-${{ matrix.plat }}
-        path: ${{ github.workspace }}/.kraftkit/oci/digests
-        if-no-files-found: error
+      - name: Archive OCI artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: oci-artifacts-${{ matrix.arch }}-${{ matrix.plat }}
+          path: ${{ github.workspace }}/.kraftkit/oci
+          if-no-files-found: error
 
   test:
     needs: [build]
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Run Dragonfly with QEMU and test with redis-cli
-      uses: unikraft/kraftkit@staging
-      working-directory: library/dragonfly/1.14
-      with:
-        run: |
-          set -xe
-          kraft run --rm -p 6379:6379 --plat qemu --arch x86_64 -M 256M unikraft.org/dragonfly:1.14 &
-          sleep 10
-          redis-cli -h 127.0.0.1 -p 6379 ping | grep PONG || (echo "Dragonfly did not respond correctly." && exit 1)
+      - uses: actions/checkout@v4
+
+      - name: Download QEMU OCI artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: oci-artifacts-x86_64-qemu
+          path: .kraftkit/oci
+
+      - name: Run Dragonfly with QEMU and test with redis-cli
+        uses: unikraft/kraftkit@staging
+        working-directory: library/dragonfly/1.14
+        with:
+          run: |
+            set -xe
+            kraft run --rm -p 6379:6379 --plat qemu --arch x86_64 -M 256M --no-pull index.unikraft.io/unikraft.org/dragonfly:1.14 &
+            sleep 10
+            redis-cli -h 127.0.0.1 -p 6379 ping | grep PONG || (echo "Dragonfly did not respond correctly." && exit 1)
 
   push:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
@@ -79,17 +87,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Login to OCI registry
-      uses: docker/login-action@v3
-      with:
-        registry: index.unikraft.io
-        username: ${{ secrets.REG_USERNAME }}
-        password: ${{ secrets.REG_TOKEN }}
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
 
-    - name: Retrieve, merge and push OCI digests
-      uses: ./.github/actions/merge-oci-digests
-      with:
-        name: index.unikraft.io/unikraft.org/dragonfly:1.14
-        push: true
+      - name: Retrieve, merge and push OCI digests
+        uses: ./.github/actions/merge-oci-digests
+        with:
+          name: index.unikraft.io/unikraft.org/dragonfly:1.14
+          push: true

--- a/.github/workflows/library-dragonfly1.14.yaml
+++ b/.github/workflows/library-dragonfly1.14.yaml
@@ -2,22 +2,22 @@ name: library/dragonfly:1.14
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Everyday at 12AM
+  - cron: '0 0 * * *' # Everyday at 12AM
 
   push:
     branches: [main]
     paths:
-      - 'library/dragonfly/1.14/**'
-      - '.github/workflows/library-dragonfly1.14.yaml'
-      - '!library/dragonfly/1.14/README.md'
+    - 'library/dragonfly/1.14/**'
+    - '.github/workflows/library-dragonfly1.14.yaml'
+    - '!library/dragonfly/1.14/README.md'
 
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
     paths:
-      - 'library/dragonfly/1.14/**'
-      - '.github/workflows/library-dragonfly1.14.yaml'
-      - '!library/dragonfly/1.14/README.md'
+    - 'library/dragonfly/1.14/**'
+    - '.github/workflows/library-dragonfly1.14.yaml'
+    - '!library/dragonfly/1.14/README.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
@@ -29,57 +29,48 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - plat: qemu
-            arch: x86_64
-          - plat: fc
-            arch: x86_64
+        - plat: qemu
+          arch: x86_64
+        - plat: fc
+          arch: x86_64
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
 
-      - name: Build dragonfly1.14
-        uses: unikraft/kraftkit@staging
-        with:
-          loglevel: debug
-          workdir: library/dragonfly/1.14
-          runtimedir: /github/workspace/.kraftkit
-          plat: ${{ matrix.plat }}
-          arch: ${{ matrix.arch }}
-          push: false
-          output: oci://index.unikraft.io/unikraft.org/dragonfly:1.14
+    - name: Build dragonfly1.14
+      uses: unikraft/kraftkit@staging
+      with:
+        loglevel: debug
+        workdir: library/dragonfly/1.14
+        runtimedir: /github/workspace/.kraftkit
+        plat: ${{ matrix.plat }}
+        arch: ${{ matrix.arch }}
+        push: false
+        output: oci://index.unikraft.io/unikraft.org/dragonfly:1.14
 
-      - name: Archive OCI digests
-        uses: actions/upload-artifact@v4
-        with:
-          name: oci-digests-${{ matrix.arch }}-${{ matrix.plat }}
-          path: ${{ github.workspace }}/.kraftkit/oci/digests
-          if-no-files-found: error
+    - name: Archive OCI digests
+      uses: actions/upload-artifact@v4
+      with:
+        name: oci-digests-${{ matrix.arch }}-${{ matrix.plat }}
+        path: ${{ github.workspace }}/.kraftkit/oci/digests
+        if-no-files-found: error
 
   test:
     needs: [build]
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install kraft CLI
-        run: |
-          curl -fsSL https://get.kraft.sh | sh
-          echo "$HOME/.unikraft/bin" >> $GITHUB_PATH
-
-      - name: Setup dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y build-essential qemu-system-x86 redis-tools
-
-      - name: Run Dragonfly with QEMU and test with redis-cli
-        working-directory: library/dragonfly/1.14
-        run: |
-          kraft run --rm -p 6379:6379 --plat qemu --arch x86_64 -M 256M unikraft.org/dragonfly:1.14 &
-          sleep 10
-          redis-cli -h 127.0.0.1 -p 6379 ping | grep PONG || (echo "Dragonfly did not respond correctly." && exit 1)
+    - uses: actions/checkout@v4
+    - name: Run Dragonfly with QEMU and test with redis-cli
+      uses: unikraft/kraftkit@staging
+      working-directory: library/dragonfly/1.14
+      run: |
+        set -xe
+        kraft run --rm -p 6379:6379 --plat qemu --arch x86_64 -M 256M unikraft.org/dragonfly:1.14 &
+        sleep 10
+        redis-cli -h 127.0.0.1 -p 6379 ping | grep PONG || (echo "Dragonfly did not respond correctly." && exit 1)
 
   push:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
@@ -87,17 +78,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
 
-      - name: Login to OCI registry
-        uses: docker/login-action@v3
-        with:
-          registry: index.unikraft.io
-          username: ${{ secrets.REG_USERNAME }}
-          password: ${{ secrets.REG_TOKEN }}
+    - name: Login to OCI registry
+      uses: docker/login-action@v3
+      with:
+        registry: index.unikraft.io
+        username: ${{ secrets.REG_USERNAME }}
+        password: ${{ secrets.REG_TOKEN }}
 
-      - name: Retrieve, merge and push OCI digests
-        uses: ./.github/actions/merge-oci-digests
-        with:
-          name: index.unikraft.io/unikraft.org/dragonfly:1.14
-          push: true
+    - name: Retrieve, merge and push OCI digests
+      uses: ./.github/actions/merge-oci-digests
+      with:
+        name: index.unikraft.io/unikraft.org/dragonfly:1.14
+        push: true


### PR DESCRIPTION
This PR adds a GitHub Actions workflow which builds and tests the dragonfly:1.14 unikernel via kraft run and redis-cli ping.