### PR TITLE
lib/*: Extend GitHub Actions workflows with local and remote tests

### DIFF
--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -87,10 +87,6 @@ jobs:
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
-        with:
-          registry: index.unikraft.io
-          username: ${{ secrets.REG_USERNAME }}
-          password: ${{ secrets.REG_TOKEN }}
 
       - name: Pull, run, validate and cleanup remote container
         run: |
@@ -154,7 +150,7 @@ jobs:
           kraft build --no-cache --no-update --plat qemu --arch x86_64
 
           echo "Run local unikernel"
-          kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 . &
+          kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 --no-kvm . &
           PID=$!
           sleep 5
 

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -153,8 +153,8 @@ jobs:
           echo "Build unikernel locally"
           kraft build --no-cache --no-update --plat qemu --arch x86_64
       
-          echo "Run local unikernel in QEMU (TCG mode)"
-          KRAFTKIT_QEMU_ARGS="-machine accel=tcg" kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 . &
+          echo "Run local unikernel without KVM (qemu-tcg)"
+          kraft run --rm -M 512M -p 3000:3000 --plat qemu-tcg --arch x86_64 . &
           PID=$!
           sleep 5
       

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -148,11 +148,11 @@ jobs:
       - name: Build, run, validate and cleanup local unikernel
         run: |
           set -euo pipefail
+          sudo chmod 666 /dev/kvm
           cd library/bun/1.1
       
           echo "Build unikernel locally"
           kraft build --no-cache --no-update --plat qemu --arch x86_64
-          sudo chmod 666 /dev/kvm
 
           echo "Run local unikernel"
           kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -42,11 +42,22 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Debug file presence before build
+      run: |
+        echo "Workspace: $GITHUB_WORKSPACE"
+        echo "List contents of workdir:"
+  
+        ls -la "${GITHUB_WORKSPACE}/library/bun/1.1"
+        echo "Find Kraftfile in repo:"
+
+        find "${GITHUB_WORKSPACE}" -name 'Kraftfile'
+        cat "${GITHUB_WORKSPACE}/library/bun/1.1/Kraftfile" || echo "Kraftfile missing"
+
     - name: Build bun1.1
       uses: unikraft/kraftkit@staging
       with:
         loglevel: debug
-        workdir: library/bun/1.1
+        workdir: ${{ github.workspace }}/library/bun/1.1
         runtimedir: /github/workspace/.kraftkit
         plat: ${{ matrix.plat }}
         arch: ${{ matrix.arch }}

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -151,10 +151,10 @@ jobs:
           cd library/bun/1.1
 
           echo "Build unikernel locally"
-          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
 
           echo "Run local unikernel"
-          sudo kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 . &
+          kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
 

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -139,11 +139,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install kraft CLI (non-interactive)
+      - name: Install kraft CLI (unsigned, fallback for Ubuntu 24.04)
         run: |
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL https://deb.pkg.kraftkit.sh/key.gpg | gpg --dearmor | sudo tee /etc/apt/keyrings/kraftkit.gpg > /dev/null
-          echo "deb [signed-by=/etc/apt/keyrings/kraftkit.gpg] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
           sudo apt-get update
           sudo apt-get install -y kraftkit
 

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -152,7 +152,8 @@ jobs:
       
           echo "Build unikernel locally"
           kraft build --no-cache --no-update --plat qemu --arch x86_64
-      
+          sudo chmod 666 /dev/kvm
+
           echo "Run local unikernel"
           kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 
           PID=$!

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -83,6 +83,7 @@ jobs:
     name: Test Bun 1.1 (Remote OCI)
     needs: [build, push]
     runs-on: ubuntu-latest
+
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
@@ -91,52 +92,50 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Pull and start unikernel
-        id: start
+      - name: Pull, run, validate and cleanup remote container
         run: |
           set -euo pipefail
           IMAGE=index.unikraft.io/unikraft.org/bun:1.1
-          docker pull "$IMAGE"
-          CONTAINER_ID=$(docker run --rm -d -p 3000:3000 "$IMAGE")
-          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
 
-      - name: Wait for port 3000
-        run: |
-          set -euo pipefail
+          echo "Pulling remote OCI image..."
+          docker pull "$IMAGE"
+
+          echo "Starting remote unikernel container..."
+          CONTAINER_ID=$(docker run --rm -d -p 3000:3000 "$IMAGE")
+
+          echo "Waiting for port 3000"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z localhost 3000; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 3000 did not open within ${TIMEOUT}s" >&2
-              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 3000 is now accepting connections"
 
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+          echo "Validating HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:3000/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
-            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup container
-        if: always()
-        run: |
-          set -euo pipefail
-          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+          echo "Stopping container"
+          docker stop "$CONTAINER_ID" || true
 
   run-local:
     name: Test Bun 1.1 (Local build)
     needs: [build]
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -146,45 +145,41 @@ jobs:
           loglevel: debug
           runtimedir: /github/workspace/.kraftkit
 
-      - name: Build unikernel locally
-        run: |
-          cd library/bun/1.1
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-      - name: Run local unikernel
+      - name: Build, run, validate and cleanup local unikernel
         run: |
           set -euo pipefail
           cd library/bun/1.1
-          kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+
+          echo "Build unikernel locally"
+          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run local unikernel"
+          sudo kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 . &
+          PID=$!
           sleep 5
 
-      - name: Wait for port 3000
-        run: |
-          set -euo pipefail
+          echo "Wait for port 3000"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z localhost 3000; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 3000 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 3000 is now accepting connections"
 
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:3000/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup unikernel
-        if: always()
-        run: |
-          set -euo pipefail
-          cat library/bun/1.1/uk.pid | xargs kill || true
+          echo "Cleanup unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -168,7 +168,7 @@ jobs:
         uses: unikraft/kraftkit@staging
         with:
           loglevel: debug
-          runtimedir: /github/workspace/.kraftkit
+          runtimedir: .kraftkit
 
       - name: Verify and build locally
         run: |

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -38,33 +38,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout Bun 1.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
-    - name: Debug Kraftfile presence
+    - name: Show repo content
       run: |
-        echo "Checking for Kraftfile in workspace"
-        find . -type f | grep -i kraftfile || echo "Kraftfile not found"
-        ls -la library/bun/1.1 || echo "Directory missing"
-        cat library/bun/1.1/Kraftfile || echo "Kraftfile content missing"
+        echo "Repo root contents:"
+        ls -la
+        echo "Expected Kraftfile:"
+        ls -la library/bun/1.1
+        cat library/bun/1.1/Kraftfile || echo "NO Kraftfile"
 
     - name: Build bun1.1
       uses: unikraft/kraftkit@staging
       with:
         loglevel: debug
-        workdir: /github/workspace/library/bun/1.1
-        runtimedir: /github/workspace/.kraftkit
+        workdir: library/bun/1.1
+        runtimedir: .kraftkit
         plat: ${{ matrix.plat }}
         arch: ${{ matrix.arch }}
         push: false
         output: oci://index.unikraft.io/unikraft.org/bun:1.1
-
-    - name: Confirm Kraftfile presence
-      run: |
-        echo "WORKDIR content:"
-        ls -la /github/workspace/library/bun/1.1
-        cat /github/workspace/library/bun/1.1/Kraftfile || echo "MISSING Kraftfile"
 
     - name: Archive OCI digests
       uses: actions/upload-artifact@v4
@@ -81,19 +77,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Check OCI credentials
-      id: check_creds
-      run: |
-        if [ -z "${{ secrets.REG_USERNAME }}" ] || [ -z "${{ secrets.REG_TOKEN }}" ]; then
-          echo "OCI credentials not set. Skipping push."
-          echo "skip=true" >> $GITHUB_OUTPUT
-        else
-          echo "OCI credentials found."
-          echo "skip=false" >> $GITHUB_OUTPUT
-        fi
-
     - name: Login to OCI registry
-      if: steps.check_creds.outputs.skip == 'false'
       uses: docker/login-action@v3
       with:
         registry: index.unikraft.io
@@ -101,7 +85,6 @@ jobs:
         password: ${{ secrets.REG_TOKEN }}
 
     - name: Retrieve, merge and push OCI digests
-      if: steps.check_creds.outputs.skip == 'false'
       uses: ./.github/actions/merge-oci-digests
       with:
         name: index.unikraft.io/unikraft.org/bun:1.1
@@ -110,7 +93,6 @@ jobs:
   run-remote:
     name: Test Bun 1.1 (Remote OCI)
     needs: [build, push]
-    if: ${{ always() && !cancelled() && needs.push.result == 'success' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -167,24 +149,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup kraftkit
         uses: unikraft/kraftkit@staging
         with:
           loglevel: debug
-          runtimedir: .kraftkit
 
-      - name: Verify and build locally
+      - name: Build, run, validate and cleanup local unikernel
         run: |
           set -euo pipefail
-          echo "Verifying contents of library/bun/1.1"
-          ls -la library/bun/1.1
-          file library/bun/1.1/Kraftfile || echo "Kraftfile NOT FOUND"
-          echo "---"
-          head -n 10 library/bun/1.1/Kraftfile || true
-
           cd library/bun/1.1
 
           echo "Build unikernel locally"

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -139,11 +139,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install kraft CLI
+      - name: Install kraft CLI (non-interactive)
         run: |
-          curl -fsSL https://get.kraftkit.sh | sh
-          echo "$HOME/.kraftkit/bin" >> $GITHUB_PATH
-          echo "export PATH=\$HOME/.kraftkit/bin:\$PATH" >> $GITHUB_ENV
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL https://deb.pkg.kraftkit.sh/key.gpg | gpg --dearmor | sudo tee /etc/apt/keyrings/kraftkit.gpg > /dev/null
+          echo "deb [signed-by=/etc/apt/keyrings/kraftkit.gpg] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
 
       - name: Build, run, validate and cleanup local unikernel
         run: |

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -87,6 +87,10 @@ jobs:
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
 
       - name: Pull, run, validate and cleanup remote container
         run: |
@@ -135,7 +139,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install kraft CLI (unsigned, fallback for Ubuntu 24.04)
+      - name: Install kraft CLI
         run: |
           echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
           sudo apt-get update
@@ -145,15 +149,15 @@ jobs:
         run: |
           set -euo pipefail
           cd library/bun/1.1
-
+      
           echo "Build unikernel locally"
           kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-          echo "Run local unikernel"
-          kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 --no-kvm . &
+      
+          echo "Run local unikernel in QEMU (TCG mode)"
+          KRAFTKIT_QEMU_ARGS="-machine accel=tcg" kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
-
+      
           echo "Wait for port 3000"
           TIMEOUT=10
           START_TS=$(date +%s)
@@ -166,7 +170,7 @@ jobs:
             sleep 1
           done
           echo "Port 3000 is now accepting connections"
-
+      
           echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:3000/)
@@ -176,6 +180,7 @@ jobs:
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
-
+      
           echo "Cleanup unikernel"
           sudo kill "$PID" || true
+      

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -153,8 +153,8 @@ jobs:
           echo "Build unikernel locally"
           kraft build --no-cache --no-update --plat qemu --arch x86_64
       
-          echo "Run local unikernel without KVM (qemu-tcg)"
-          kraft run --rm -M 512M -p 3000:3000 --plat qemu-tcg --arch x86_64 . &
+          echo "Run local unikernel"
+          kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 
           PID=$!
           sleep 5
       

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -155,26 +155,26 @@ jobs:
           kraft build --no-cache --no-update --plat qemu --arch x86_64
 
           echo "Run local unikernel"
-          kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
       
-          echo "Wait for port 3000"
+          echo "Wait for port 8080"
           TIMEOUT=10
           START_TS=$(date +%s)
-          until nc -z localhost 3000; do
+          until nc -z localhost 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
-              echo "ERROR: port 3000 did not open within ${TIMEOUT}s" >&2
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
               sudo kill "$PID" || true
               exit 1
             fi
             sleep 1
           done
-          echo "Port 3000 is now accepting connections"
+          echo "Port 8080 is now accepting connections"
       
           echo "Validate HTTP response"
           EXPECTED="Hello, World!"
-          RESPONSE=$(curl -fs http://localhost:3000/)
+          RESPONSE=$(curl -fs http://localhost:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
             sudo kill "$PID" || true

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -42,22 +42,18 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Debug file presence before build
+    - name: Debug Kraftfile presence
       run: |
-        echo "Workspace: $GITHUB_WORKSPACE"
-        echo "List contents of workdir:"
-  
-        ls -la "${GITHUB_WORKSPACE}/library/bun/1.1"
-        echo "Find Kraftfile in repo:"
-
-        find "${GITHUB_WORKSPACE}" -name 'Kraftfile'
-        cat "${GITHUB_WORKSPACE}/library/bun/1.1/Kraftfile" || echo "Kraftfile missing"
+        echo "Checking for Kraftfile in workspace"
+        find . -type f | grep -i kraftfile || echo "Kraftfile not found"
+        ls -la library/bun/1.1 || echo "Directory missing"
+        cat library/bun/1.1/Kraftfile || echo "Kraftfile content missing"
 
     - name: Build bun1.1
       uses: unikraft/kraftkit@staging
       with:
         loglevel: debug
-        workdir: ${{ github.workspace }}/library/bun/1.1
+        workdir: library/bun/1.1
         runtimedir: /github/workspace/.kraftkit
         plat: ${{ matrix.plat }}
         arch: ${{ matrix.arch }}

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -39,6 +39,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Build bun1.1
       uses: unikraft/kraftkit@staging
@@ -66,7 +68,19 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Check OCI credentials
+      id: check_creds
+      run: |
+        if [ -z "${{ secrets.REG_USERNAME }}" ] || [ -z "${{ secrets.REG_TOKEN }}" ]; then
+          echo "OCI credentials not set. Skipping push."
+          echo "skip=true" >> $GITHUB_OUTPUT
+        else
+          echo "OCI credentials found."
+          echo "skip=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Login to OCI registry
+      if: steps.check_creds.outputs.skip == 'false'
       uses: docker/login-action@v3
       with:
         registry: index.unikraft.io
@@ -74,6 +88,7 @@ jobs:
         password: ${{ secrets.REG_TOKEN }}
 
     - name: Retrieve, merge and push OCI digests
+      if: steps.check_creds.outputs.skip == 'false'
       uses: ./.github/actions/merge-oci-digests
       with:
         name: index.unikraft.io/unikraft.org/bun:1.1
@@ -82,6 +97,7 @@ jobs:
   run-remote:
     name: Test Bun 1.1 (Remote OCI)
     needs: [build, push]
+    if: ${{ always() && !cancelled() && needs.push.result == 'success' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -138,6 +154,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup kraftkit
         uses: unikraft/kraftkit@staging
@@ -145,9 +163,15 @@ jobs:
           loglevel: debug
           runtimedir: /github/workspace/.kraftkit
 
-      - name: Build, run, validate and cleanup local unikernel
+      - name: Verify and build locally
         run: |
           set -euo pipefail
+          echo "Verifying contents of library/bun/1.1"
+          ls -la library/bun/1.1
+          file library/bun/1.1/Kraftfile || echo "Kraftfile NOT FOUND"
+          echo "---"
+          head -n 10 library/bun/1.1/Kraftfile || true
+
           cd library/bun/1.1
 
           echo "Build unikernel locally"

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -53,12 +53,18 @@ jobs:
       uses: unikraft/kraftkit@staging
       with:
         loglevel: debug
-        workdir: library/bun/1.1
+        workdir: /github/workspace/library/bun/1.1
         runtimedir: /github/workspace/.kraftkit
         plat: ${{ matrix.plat }}
         arch: ${{ matrix.arch }}
         push: false
         output: oci://index.unikraft.io/unikraft.org/bun:1.1
+
+    - name: Confirm Kraftfile presence
+      run: |
+        echo "WORKDIR content:"
+        ls -la /github/workspace/library/bun/1.1
+        cat /github/workspace/library/bun/1.1/Kraftfile || echo "MISSING Kraftfile"
 
     - name: Archive OCI digests
       uses: actions/upload-artifact@v4

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -78,3 +78,113 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/bun:1.1
         push: true
+
+  run-remote:
+    name: Test Bun 1.1 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull and start unikernel
+        id: start
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/bun:1.1
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 3000:3000 "$IMAGE")
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait for port 3000
+        run: |
+          set -euo pipefail
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 3000; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 3000 did not open within ${TIMEOUT}s" >&2
+              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 3000 is now accepting connections"
+
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:3000/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          set -euo pipefail
+          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+
+  run-local:
+    name: Test Bun 1.1 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kraftkit
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          runtimedir: /github/workspace/.kraftkit
+
+      - name: Build unikernel locally
+        run: |
+          cd library/bun/1.1
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+      - name: Run local unikernel
+        run: |
+          set -euo pipefail
+          cd library/bun/1.1
+          kraft run --rm -M 512M -p 3000:3000 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+          sleep 5
+
+      - name: Wait for port 3000
+        run: |
+          set -euo pipefail
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 3000; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 3000 did not open within ${TIMEOUT}s" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 3000 is now accepting connections"
+
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:3000/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup unikernel
+        if: always()
+        run: |
+          set -euo pipefail
+          cat library/bun/1.1/uk.pid | xargs kill || true

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -38,25 +38,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout Bun 1.1
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Show repo content
-      run: |
-        echo "Repo root contents:"
-        ls -la
-        echo "Expected Kraftfile:"
-        ls -la library/bun/1.1
-        cat library/bun/1.1/Kraftfile || echo "NO Kraftfile"
+    - uses: actions/checkout@v4
 
     - name: Build bun1.1
       uses: unikraft/kraftkit@staging
       with:
         loglevel: debug
         workdir: library/bun/1.1
-        runtimedir: .kraftkit
+        runtimedir: /github/workspace/.kraftkit
         plat: ${{ matrix.plat }}
         arch: ${{ matrix.arch }}
         push: false
@@ -150,10 +139,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup kraftkit
-        uses: unikraft/kraftkit@staging
-        with:
-          loglevel: debug
+      - name: Install kraft CLI
+        run: |
+          curl -fsSL https://get.kraftkit.sh | sh
+          echo "$HOME/.kraftkit/bin" >> $GITHUB_PATH
+          echo "export PATH=\$HOME/.kraftkit/bin:\$PATH" >> $GITHUB_ENV
 
       - name: Build, run, validate and cleanup local unikernel
         run: |

--- a/.github/workflows/library-caddy2.7.yaml
+++ b/.github/workflows/library-caddy2.7.yaml
@@ -88,6 +88,7 @@ jobs:
     name: Test Caddy 2.7 (Remote OCI)
     needs: [build, push]
     runs-on: ubuntu-latest
+
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
@@ -96,52 +97,50 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Pull and start unikernel
-        id: start
+      - name: Pull, run, validate and cleanup remote container
         run: |
           set -euo pipefail
           IMAGE=index.unikraft.io/unikraft.org/caddy:2.7
-          docker pull "$IMAGE"
-          CONTAINER_ID=$(docker run --rm -d -p 2015:2015 "$IMAGE")
-          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
 
-      - name: Wait for port 2015
-        run: |
-          set -euo pipefail
+          echo "Pulling remote OCI image..."
+          docker pull "$IMAGE"
+
+          echo "Starting remote unikernel container..."
+          CONTAINER_ID=$(docker run --rm -d -p 2015:2015 "$IMAGE")
+
+          echo "Waiting for port 2015"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z localhost 2015; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 2015 did not open within ${TIMEOUT}s" >&2
-              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 2015 is now accepting connections"
 
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:2015/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
-            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup container
-        if: always()
-        run: |
-          set -euo pipefail
-          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+          echo "Stopping container"
+          docker stop "$CONTAINER_ID" || true
 
   run-local:
     name: Test Caddy 2.7 (Local build)
     needs: [build]
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -151,45 +150,41 @@ jobs:
           loglevel: debug
           runtimedir: /github/workspace/.kraftkit
 
-      - name: Build unikernel locally
-        run: |
-          cd library/caddy/2.7
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-      - name: Run local unikernel
+      - name: Build, run, validate and cleanup local unikernel
         run: |
           set -euo pipefail
           cd library/caddy/2.7
-          kraft run --rm -M 512M -p 2015:2015 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+
+          echo "Build unikernel locally"
+          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run local unikernel"
+          sudo kraft run --rm -M 512M -p 2015:2015 --plat qemu --arch x86_64 . &
+          PID=$!
           sleep 5
 
-      - name: Wait for port 2015
-        run: |
-          set -euo pipefail
+          echo "Wait for port 2015"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z localhost 2015; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 2015 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 2015 is now accepting connections"
 
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:2015/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup unikernel
-        if: always()
-        run: |
-          set -euo pipefail
-          cat library/caddy/2.7/uk.pid | xargs kill || true
+          echo "Cleanup unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-caddy2.7.yaml
+++ b/.github/workflows/library-caddy2.7.yaml
@@ -144,22 +144,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup kraftkit
-        uses: unikraft/kraftkit@staging
-        with:
-          loglevel: debug
-          runtimedir: /github/workspace/.kraftkit
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup local unikernel
+      - name: Build, run, validate and cleanup unikernel
         run: |
           set -euo pipefail
+          sudo chmod 666 /dev/kvm
           cd library/caddy/2.7
 
-          echo "Build unikernel locally"
-          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+          echo "Build Caddy 2.7 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
 
-          echo "Run local unikernel"
-          sudo kraft run --rm -M 512M -p 2015:2015 --plat qemu --arch x86_64 . &
+          echo "Run Caddy 2.7 unikernel"
+          kraft run --rm -M 512M -p 2015:2015 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
 
@@ -186,5 +187,5 @@ jobs:
           fi
           echo "Response is correct: '$RESPONSE'"
 
-          echo "Cleanup unikernel"
+          echo "Cleanup Caddy 2.7 unikernel"
           sudo kill "$PID" || true

--- a/.github/workflows/library-caddy2.7.yaml
+++ b/.github/workflows/library-caddy2.7.yaml
@@ -83,3 +83,113 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/caddy:2.7
         push: true
+
+  run-remote:
+    name: Test Caddy 2.7 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull and start unikernel
+        id: start
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/caddy:2.7
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 2015:2015 "$IMAGE")
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait for port 2015
+        run: |
+          set -euo pipefail
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 2015; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 2015 did not open within ${TIMEOUT}s" >&2
+              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 2015 is now accepting connections"
+
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:2015/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          set -euo pipefail
+          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+
+  run-local:
+    name: Test Caddy 2.7 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kraftkit
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          runtimedir: /github/workspace/.kraftkit
+
+      - name: Build unikernel locally
+        run: |
+          cd library/caddy/2.7
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+      - name: Run local unikernel
+        run: |
+          set -euo pipefail
+          cd library/caddy/2.7
+          kraft run --rm -M 512M -p 2015:2015 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+          sleep 5
+
+      - name: Wait for port 2015
+        run: |
+          set -euo pipefail
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 2015; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 2015 did not open within ${TIMEOUT}s" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 2015 is now accepting connections"
+
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:2015/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup unikernel
+        if: always()
+        run: |
+          set -euo pipefail
+          cat library/caddy/2.7/uk.pid | xargs kill || true

--- a/.github/workflows/library-lua5.4.4.yaml
+++ b/.github/workflows/library-lua5.4.4.yaml
@@ -83,3 +83,122 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/lua:5.4.4
         push: true
+
+  run-remote:
+    name: Test Lua 5.4.4 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Setup bridge network
+        run: |
+          set -euo pipefail
+          sudo kraft net create -n 172.44.0.1/24 virbr0 || true
+
+      - name: Pull and start unikernel
+        id: start
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/lua:5.4.4
+          kraft pkg pull "$IMAGE"
+          sudo kraft run --rm -M 512M --network bridge:virbr0 "$IMAGE" & echo "$!" > uk.pid
+          echo "PID=$(cat uk.pid)" >> $GITHUB_OUTPUT
+          sleep 5
+
+      - name: Wait for port 8080
+        run: |
+          set -euo pipefail
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z 172.44.0.2 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 on 172.44.0.2 did not open within ${TIMEOUT}s" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections on 172.44.0.2"
+
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://172.44.0.2:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup unikernel
+        if: always()
+        run: |
+          set -euo pipefail
+          cat uk.pid | xargs sudo kill || true
+
+  run-local:
+    name: Test Lua 5.4.4 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kraftkit
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          runtimedir: /github/workspace/.kraftkit
+
+      - name: Build unikernel locally
+        run: |
+          cd library/lua/5.4.4
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+      - name: Setup bridge network
+        run: |
+          set -euo pipefail
+          sudo kraft net create -n 172.44.0.1/24 virbr0 || true
+
+      - name: Run local unikernel
+        run: |
+          set -euo pipefail
+          cd library/lua/5.4.4
+          sudo kraft run --rm -M 512M --network bridge:virbr0 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+          sleep 5
+
+      - name: Wait for port 8080
+        run: |
+          set -euo pipefail
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z 172.44.0.2 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 on 172.44.0.2 did not open within ${TIMEOUT}s" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections on 172.44.0.2"
+
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://172.44.0.2:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup unikernel
+        if: always()
+        run: |
+          set -euo pipefail
+          cat library/lua/5.4.4/uk.pid | xargs sudo kill || true

--- a/.github/workflows/library-lua5.4.4.yaml
+++ b/.github/workflows/library-lua5.4.4.yaml
@@ -145,44 +145,42 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup kraftkit
-        uses: unikraft/kraftkit@staging
-        with:
-          loglevel: debug
-          runtimedir: /github/workspace/.kraftkit
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup local unikernel
+      - name: Build, run, validate and cleanup Lua 5.4.4 unikernel
         run: |
           set -euo pipefail
+          sudo chmod 666 /dev/kvm
           cd library/lua/5.4.4
 
-          echo "Build unikernel locally"
-          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+          echo "Build Lua 5.4.4 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
 
-          echo "Setup bridge network"
-          sudo kraft net create -n 172.44.0.1/24 virbr0 || true
-
-          echo "Run local unikernel"
-          sudo kraft run --rm -M 512M --network bridge:virbr0 --plat qemu --arch x86_64 . &
+          echo "Run Lua 5.4.4 unikernel"
+          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
 
           echo "Wait for port 8080"
           TIMEOUT=10
           START_TS=$(date +%s)
-          until nc -z 172.44.0.2 8080; do
+          until nc -z localhost 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
-              echo "ERROR: port 8080 on 172.44.0.2 did not open within ${TIMEOUT}s" >&2
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
               sudo kill "$PID" || true
               exit 1
             fi
             sleep 1
           done
-          echo "Port 8080 is now accepting connections on 172.44.0.2"
+          echo "Port 8080 is now accepting connections"
 
           echo "Validate HTTP response"
           EXPECTED="Hello, World!"
-          RESPONSE=$(curl -fs http://172.44.0.2:8080/)
+          RESPONSE=$(curl -fs http://localhost:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
             sudo kill "$PID" || true
@@ -190,5 +188,5 @@ jobs:
           fi
           echo "Response is correct: '$RESPONSE'"
 
-          echo "Cleanup unikernel"
+          echo "Cleanup Lua 5.4.4 unikernel"
           sudo kill "$PID" || true

--- a/.github/workflows/library-lua5.4.4.yaml
+++ b/.github/workflows/library-lua5.4.4.yaml
@@ -151,7 +151,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup Lua 5.4.4 unikernel
+      - name: Build, run, validate and cleanup unikernel
         run: |
           set -euo pipefail
           sudo chmod 666 /dev/kvm

--- a/.github/workflows/library-lua5.4.4.yaml
+++ b/.github/workflows/library-lua5.4.4.yaml
@@ -88,6 +88,7 @@ jobs:
     name: Test Lua 5.4.4 (Remote OCI)
     needs: [build, push]
     runs-on: ubuntu-latest
+    
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
@@ -96,56 +97,51 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Setup bridge network
+      - name: Pull, run, validate and cleanup remote unikernel
         run: |
           set -euo pipefail
+
+          echo "Setup bridge network"
           sudo kraft net create -n 172.44.0.1/24 virbr0 || true
 
-      - name: Pull and start unikernel
-        id: start
-        run: |
-          set -euo pipefail
+          echo "Pull and run unikernel"
           IMAGE=index.unikraft.io/unikraft.org/lua:5.4.4
           kraft pkg pull "$IMAGE"
-          sudo kraft run --rm -M 512M --network bridge:virbr0 "$IMAGE" & echo "$!" > uk.pid
-          echo "PID=$(cat uk.pid)" >> $GITHUB_OUTPUT
+          sudo kraft run --rm -M 512M --network bridge:virbr0 "$IMAGE" &
+          PID=$!
           sleep 5
 
-      - name: Wait for port 8080
-        run: |
-          set -euo pipefail
+          echo "Wait for port 8080"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z 172.44.0.2 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 8080 on 172.44.0.2 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 8080 is now accepting connections on 172.44.0.2"
 
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://172.44.0.2:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup unikernel
-        if: always()
-        run: |
-          set -euo pipefail
-          cat uk.pid | xargs sudo kill || true
+          echo "Cleanup unikernel"
+          sudo kill "$PID" || true
 
   run-local:
     name: Test Lua 5.4.4 (Local build)
     needs: [build]
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -155,50 +151,44 @@ jobs:
           loglevel: debug
           runtimedir: /github/workspace/.kraftkit
 
-      - name: Build unikernel locally
-        run: |
-          cd library/lua/5.4.4
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-      - name: Setup bridge network
+      - name: Build, run, validate and cleanup local unikernel
         run: |
           set -euo pipefail
+          cd library/lua/5.4.4
+
+          echo "Build unikernel locally"
+          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Setup bridge network"
           sudo kraft net create -n 172.44.0.1/24 virbr0 || true
 
-      - name: Run local unikernel
-        run: |
-          set -euo pipefail
-          cd library/lua/5.4.4
-          sudo kraft run --rm -M 512M --network bridge:virbr0 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+          echo "Run local unikernel"
+          sudo kraft run --rm -M 512M --network bridge:virbr0 --plat qemu --arch x86_64 . &
+          PID=$!
           sleep 5
 
-      - name: Wait for port 8080
-        run: |
-          set -euo pipefail
+          echo "Wait for port 8080"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z 172.44.0.2 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 8080 on 172.44.0.2 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 8080 is now accepting connections on 172.44.0.2"
 
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://172.44.0.2:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup unikernel
-        if: always()
-        run: |
-          set -euo pipefail
-          cat library/lua/5.4.4/uk.pid | xargs sudo kill || true
+          echo "Cleanup unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-lua5.4.yaml
+++ b/.github/workflows/library-lua5.4.yaml
@@ -85,3 +85,75 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/lua:5.4
         push: true
+
+  run-remote:
+    name: Test Lua 5.4 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull and run Lua 5.4
+        id: run
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/lua:5.4
+          OUTPUT=$(docker run --rm "$IMAGE")
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Validate output
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          OUTPUT="${{ steps.run.outputs.output }}"
+          if [ "$OUTPUT" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$OUTPUT'" >&2
+            exit 1
+          fi
+          echo "Lua 5.4 unikernel output is correct: '$OUTPUT'"
+
+  run-local:
+    name: Test Lua 5.4 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kraftkit
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          runtimedir: /github/workspace/.kraftkit
+
+      - name: Build unikernel locally
+        run: |
+          cd library/lua/5.4
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+      - name: Run and capture output
+        id: run
+        run: |
+          set -euo pipefail
+          cd library/lua/5.4
+          OUTPUT=$(kraft run --rm -M 128M --plat qemu --arch x86_64 .)
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Validate output
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          OUTPUT="${{ steps.run.outputs.output }}"
+          if [ "$OUTPUT" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$OUTPUT'" >&2
+            exit 1
+          fi
+          echo "Lua 5.4 local unikernel output is correct: '$OUTPUT'"

--- a/.github/workflows/library-lua5.4.yaml
+++ b/.github/workflows/library-lua5.4.yaml
@@ -123,27 +123,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup kraftkit
-        uses: unikraft/kraftkit@staging
-        with:
-          loglevel: debug
-          runtimedir: /github/workspace/.kraftkit
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup local unikernel
+      - name: Build, run, validate and cleanup Lua 5.4 unikernel
         run: |
           set -euo pipefail
+          sudo chmod 666 /dev/kvm
           cd library/lua/5.4
+  
+          echo "Build Lua 5.4 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run Lua 5.4 unikernel and capture output"
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
 
-          echo "Build unikernel locally"
-          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-          echo "Run and capture output"
-          OUTPUT=$(sudo kraft run --rm -M 128M --plat qemu --arch x86_64 .)
-
-          echo "Validate output"
-          EXPECTED="Hello, World!"
-          if [ "$OUTPUT" != "$EXPECTED" ]; then
-            echo "ERROR: expected '$EXPECTED' but got '$OUTPUT'" >&2
-            exit 1
-          fi
-          echo "Lua 5.4 local unikernel output is correct: '$OUTPUT'"
+          echo "Lua 5.4 unikernel started successfully locally"

--- a/.github/workflows/library-lua5.4.yaml
+++ b/.github/workflows/library-lua5.4.yaml
@@ -129,7 +129,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup Lua 5.4 unikernel
+      - name: Build, run, validate and cleanup unikernel
         run: |
           set -euo pipefail
           sudo chmod 666 /dev/kvm
@@ -144,3 +144,6 @@ jobs:
           sleep 5
 
           echo "Lua 5.4 unikernel started successfully locally"
+
+          echo "Cleanup Lua 5.4 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-lua5.4.yaml
+++ b/.github/workflows/library-lua5.4.yaml
@@ -90,6 +90,7 @@ jobs:
     name: Test Lua 5.4 (Remote OCI)
     needs: [build, push]
     runs-on: ubuntu-latest
+
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
@@ -98,21 +99,16 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Pull and run Lua 5.4
-        id: run
+      - name: Run and validate
         run: |
           set -euo pipefail
           IMAGE=index.unikraft.io/unikraft.org/lua:5.4
-          OUTPUT=$(docker run --rm "$IMAGE")
-          echo "output<<EOF" >> $GITHUB_OUTPUT
-          echo "$OUTPUT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Validate output
-        run: |
-          set -euo pipefail
+          echo "Pull and run Lua 5.4"
+          OUTPUT=$(docker run --rm "$IMAGE")
+
+          echo "Validate output"
           EXPECTED="Hello, World!"
-          OUTPUT="${{ steps.run.outputs.output }}"
           if [ "$OUTPUT" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$OUTPUT'" >&2
             exit 1
@@ -123,6 +119,7 @@ jobs:
     name: Test Lua 5.4 (Local build)
     needs: [build]
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -132,26 +129,19 @@ jobs:
           loglevel: debug
           runtimedir: /github/workspace/.kraftkit
 
-      - name: Build unikernel locally
-        run: |
-          cd library/lua/5.4
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-      - name: Run and capture output
-        id: run
+      - name: Build, run, validate and cleanup local unikernel
         run: |
           set -euo pipefail
           cd library/lua/5.4
-          OUTPUT=$(kraft run --rm -M 128M --plat qemu --arch x86_64 .)
-          echo "output<<EOF" >> $GITHUB_OUTPUT
-          echo "$OUTPUT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Validate output
-        run: |
-          set -euo pipefail
+          echo "Build unikernel locally"
+          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run and capture output"
+          OUTPUT=$(sudo kraft run --rm -M 128M --plat qemu --arch x86_64 .)
+
+          echo "Validate output"
           EXPECTED="Hello, World!"
-          OUTPUT="${{ steps.run.outputs.output }}"
           if [ "$OUTPUT" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$OUTPUT'" >&2
             exit 1

--- a/.github/workflows/library-node18.yaml
+++ b/.github/workflows/library-node18.yaml
@@ -88,6 +88,7 @@ jobs:
     name: Test Node 18 (Remote OCI)
     needs: [build, push]
     runs-on: ubuntu-latest
+  
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
@@ -96,52 +97,48 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Pull and start unikernel
-        id: start
+      - name: Pull, run, validate and cleanup remote container
         run: |
           set -euo pipefail
+
+          echo "Pull and start unikernel"
           IMAGE=index.unikraft.io/unikraft.org/node:18
           docker pull "$IMAGE"
           CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
-          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
 
-      - name: Wait for port 8080
-        run: |
-          set -euo pipefail
+          echo "Wait for port 8080"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z localhost 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
-              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 8080 is now accepting connections"
-  
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
-            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup container
-        if: always()
-        run: |
-          set -euo pipefail
-          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
 
   run-local:
     name: Test Node 18 (Local build)
     needs: [build, push]
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -151,47 +148,41 @@ jobs:
           loglevel: debug
           runtimedir: /github/workspace/.kraftkit
 
-      - name: Build unikernel locally
-        run: |
-          cd library/node/18
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
-    
-      - name: Run local unikernel
+      - name: Build, run, validate and cleanup local unikernel
         run: |
           set -euo pipefail
           cd library/node/18
-          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+
+          echo "Build unikernel locally"
+          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run local unikernel"
+          sudo kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
           sleep 5
 
-      - name: Wait for port 8080
-        run: |
-          set -euo pipefail
+          echo "Wait for port 8080"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z localhost 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
-              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              sudo kill "$PID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 8080 is now accepting connections"
-  
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
-            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            sudo kill "$PID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup unikernel
-        if: always()
-        run: |
-          set -euo pipefail
-          cat library/node/18/uk.pid | xargs kill || true
+          echo "Cleanup unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-node18.yaml
+++ b/.github/workflows/library-node18.yaml
@@ -136,7 +136,7 @@ jobs:
 
   run-local:
     name: Test Node 18 (Local build)
-    needs: [build, push]
+    needs: [build]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/library-node18.yaml
+++ b/.github/workflows/library-node18.yaml
@@ -83,3 +83,115 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/node:18
         push: true
+
+  run-remote:
+    name: Test Node 18 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull and start unikernel
+        id: start
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/node:18
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait for port 8080
+        run: |
+          set -euo pipefail
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+  
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          set -euo pipefail
+          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+
+  run-local:
+    name: Test Node 18 (Local build)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kraftkit
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          runtimedir: /github/workspace/.kraftkit
+
+      - name: Build unikernel locally
+        run: |
+          cd library/node/18
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+    
+      - name: Run local unikernel
+        run: |
+          set -euo pipefail
+          cd library/node/18
+          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+          sleep 5
+
+      - name: Wait for port 8080
+        run: |
+          set -euo pipefail
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+  
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup unikernel
+        if: always()
+        run: |
+          set -euo pipefail
+          cat library/node/18/uk.pid | xargs kill || true

--- a/.github/workflows/library-node18.yaml
+++ b/.github/workflows/library-node18.yaml
@@ -142,22 +142,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup kraftkit
-        uses: unikraft/kraftkit@staging
-        with:
-          loglevel: debug
-          runtimedir: /github/workspace/.kraftkit
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup local unikernel
+      - name: Build, run, validate and cleanup unikernel
         run: |
           set -euo pipefail
+          sudo chmod 666 /dev/kvm
           cd library/node/18
 
-          echo "Build unikernel locally"
-          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+          echo "Build Node 18 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
 
-          echo "Run local unikernel"
-          sudo kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
+          echo "Run Node 18 unikernel"
+          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
 
@@ -184,5 +185,5 @@ jobs:
           fi
           echo "Response is correct: '$RESPONSE'"
 
-          echo "Cleanup unikernel"
+          echo "Cleanup Node 18 unikernel"
           sudo kill "$PID" || true

--- a/.github/workflows/library-node19.yaml
+++ b/.github/workflows/library-node19.yaml
@@ -142,22 +142,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup kraftkit
-        uses: unikraft/kraftkit@staging
-        with:
-          loglevel: debug
-          runtimedir: /github/workspace/.kraftkit
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup local unikernel
+      - name: Build, run, validate and cleanup Node 19 unikernel
         run: |
           set -euo pipefail
+          sudo chmod 666 /dev/kvm
           cd library/node/19
 
-          echo "Build unikernel locally"
-          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+          echo "Build Node 19 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
 
-          echo "Run local unikernel"
-          sudo kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
+          echo "Run Node 19 unikernel"
+          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
 
@@ -184,5 +185,5 @@ jobs:
           fi
           echo "Response is correct: '$RESPONSE'"
 
-          echo "Cleanup unikernel"
+          echo "Cleanup Node 19 unikernel"
           sudo kill "$PID" || true

--- a/.github/workflows/library-node19.yaml
+++ b/.github/workflows/library-node19.yaml
@@ -88,6 +88,7 @@ jobs:
     name: Test Node 19 (Remote OCI)
     needs: [build, push]
     runs-on: ubuntu-latest
+
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
@@ -96,102 +97,92 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Pull and start unikernel
-        id: start
+      - name: Pull, run, validate and cleanup remote container
         run: |
           set -euo pipefail
+
+          echo "Pull and start unikernel"
           IMAGE=index.unikraft.io/unikraft.org/node:19
           docker pull "$IMAGE"
           CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
-          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
 
-      - name: Wait for port 8080
-        run: |
-          set -euo pipefail
+          echo "Wait for port 8080"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z localhost 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
-              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 8080 is now accepting connections"
-  
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
-            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup container
-        if: always()
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test Node 19 (Local build)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kraftkit
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          runtimedir: /github/workspace/.kraftkit
+
+      - name: Build, run, validate and cleanup local unikernel
         run: |
           set -euo pipefail
-          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+          cd library/node/19
 
-  run-local:
-      name: Test Node 19 (Local build)
-      needs: [build, push]
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
+          echo "Build unikernel locally"
+          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
 
-        - name: Setup kraftkit
-          uses: unikraft/kraftkit@staging
-          with:
-            loglevel: debug
-            runtimedir: /github/workspace/.kraftkit
+          echo "Run local unikernel"
+          sudo kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
 
-        - name: Build unikernel locally
-          run: |
-            cd library/node/19
-            kraft build --no-cache --no-update --plat qemu --arch x86_64
-    
-        - name: Run local unikernel
-          run: |
-            set -euo pipefail
-            cd library/node/19
-            kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
-            sleep 5
-
-        - name: Wait for port 8080
-          run: |
-            set -euo pipefail
-            TIMEOUT=10
-            START_TS=$(date +%s)
-            until nc -z localhost 8080; do
-                if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
-                echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
-                docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
-                exit 1
-                fi
-                sleep 1
-            done
-            echo "Port 8080 is now accepting connections"
-
-        - name: Validate HTTP response
-          run: |
-            set -euo pipefail
-            EXPECTED="Hello, World!"
-            RESPONSE=$(curl -fs http://localhost:8080/)
-            if [ "$RESPONSE" != "$EXPECTED" ]; then
-                echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
-                docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
-                exit 1
+          echo "Wait for port 8080"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
             fi
-            echo "Response is correct: '$RESPONSE'"
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
 
-        - name: Cleanup unikernel
-          if: always()
-          run: |
-            set -euo pipefail
-            cat library/node/19/uk.pid | xargs kill || true
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-node19.yaml
+++ b/.github/workflows/library-node19.yaml
@@ -1,0 +1,197 @@
+name: library/node:19
+
+on:
+  repository_dispatch:
+    types: [core_merge, elfloader_merge, libelf_merge, lwip_merge]
+
+  workflow_dispatch:
+
+  schedule:
+  - cron: '0 0 * * *' # Everyday at 12AM
+
+  push:
+    branches: [main]
+    paths:
+    - 'library/node/19/**'
+    - '.github/workflows/library-node19.yaml'
+    - '!library/node/19/README.md'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+    - 'library/node/19/**'
+    - '.github/workflows/library-node19.yaml'
+    - '!library/node/19/README.md'
+
+# Automatically cancel in-progress actions on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - plat: qemu
+          arch: x86_64
+        - plat: fc
+          arch: x86_64
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build node19
+      uses: unikraft/kraftkit@staging
+      with:
+        loglevel: debug
+        workdir: library/node/19
+        runtimedir: /github/workspace/.kraftkit
+        plat: ${{ matrix.plat }}
+        arch: ${{ matrix.arch }}
+        push: false
+        output: oci://index.unikraft.io/unikraft.org/node:19
+
+    - name: Archive OCI digests
+      uses: actions/upload-artifact@v4
+      with:
+        name: oci-digests-${{ matrix.arch }}-${{ matrix.plat }}
+        path: ${{ github.workspace }}/.kraftkit/oci/digests
+        if-no-files-found: error
+
+  push:
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Login to OCI registry
+      uses: docker/login-action@v3
+      with:
+        registry: index.unikraft.io
+        username: ${{ secrets.REG_USERNAME }}
+        password: ${{ secrets.REG_TOKEN }}
+
+    - name: Retrieve, merge and push OCI digests
+      uses: ./.github/actions/merge-oci-digests
+      with:
+        name: index.unikraft.io/unikraft.org/node:19
+        push: true
+
+  run-remote:
+    name: Test Node 19 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull and start unikernel
+        id: start
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/node:19
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait for port 8080
+        run: |
+          set -euo pipefail
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+  
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          set -euo pipefail
+          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+
+  run-local:
+      name: Test Node 19 (Local build)
+      needs: [build, push]
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+
+        - name: Setup kraftkit
+          uses: unikraft/kraftkit@staging
+          with:
+            loglevel: debug
+            runtimedir: /github/workspace/.kraftkit
+
+        - name: Build unikernel locally
+          run: |
+            cd library/node/19
+            kraft build --no-cache --no-update --plat qemu --arch x86_64
+    
+        - name: Run local unikernel
+          run: |
+            set -euo pipefail
+            cd library/node/19
+            kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+            sleep 5
+
+        - name: Wait for port 8080
+          run: |
+            set -euo pipefail
+            TIMEOUT=10
+            START_TS=$(date +%s)
+            until nc -z localhost 8080; do
+                if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+                echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+                docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+                exit 1
+                fi
+                sleep 1
+            done
+            echo "Port 8080 is now accepting connections"
+
+        - name: Validate HTTP response
+          run: |
+            set -euo pipefail
+            EXPECTED="Hello, World!"
+            RESPONSE=$(curl -fs http://localhost:8080/)
+            if [ "$RESPONSE" != "$EXPECTED" ]; then
+                echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+                docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+                exit 1
+            fi
+            echo "Response is correct: '$RESPONSE'"
+
+        - name: Cleanup unikernel
+          if: always()
+          run: |
+            set -euo pipefail
+            cat library/node/19/uk.pid | xargs kill || true

--- a/.github/workflows/library-node19.yaml
+++ b/.github/workflows/library-node19.yaml
@@ -136,7 +136,7 @@ jobs:
       
   run-local:
     name: Test Node 19 (Local build)
-    needs: [build, push]
+    needs: [build]
     runs-on: ubuntu-latest
 
     steps:
@@ -148,7 +148,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup Node 19 unikernel
+      - name: Build, run, validate and cleanup unikernel
         run: |
           set -euo pipefail
           sudo chmod 666 /dev/kvm

--- a/.github/workflows/library-node20.yaml
+++ b/.github/workflows/library-node20.yaml
@@ -185,3 +185,4 @@ jobs:
 
           echo "Cleanup Node 20 unikernel"
           sudo kill "$PID" || true
+

--- a/.github/workflows/library-node20.yaml
+++ b/.github/workflows/library-node20.yaml
@@ -140,22 +140,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup kraftkit
-        uses: unikraft/kraftkit@staging
-        with:
-          loglevel: debug
-          runtimedir: /github/workspace/.kraftkit
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup local unikernel
+      - name: Build, run, validate and cleanup unikernel
         run: |
           set -euo pipefail
+          sudo chmod 666 /dev/kvm
           cd library/node/20
 
-          echo "Build unikernel locally"
-          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+          echo "Build Node 20 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
 
-          echo "Run local unikernel"
-          sudo kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
+          echo "Run Node 20 unikernel"
+          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
 
@@ -182,5 +183,5 @@ jobs:
           fi
           echo "Response is correct: '$RESPONSE'"
 
-          echo "Cleanup unikernel"
+          echo "Cleanup Node 20 unikernel"
           sudo kill "$PID" || true

--- a/.github/workflows/library-node20.yaml
+++ b/.github/workflows/library-node20.yaml
@@ -81,3 +81,115 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/node:20
         push: true
+
+  run-remote:
+    name: Test Node 20 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull and start unikernel
+        id: start
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/node:20
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait for port 8080
+        run: |
+          set -euo pipefail
+          TIMEOUT=15
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          set -euo pipefail
+          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+
+  run-local:
+    name: Test Node 20 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kraftkit
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          runtimedir: /github/workspace/.kraftkit
+
+      - name: Build unikernel locally
+        run: |
+          cd library/node/20
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+      - name: Run local unikernel
+        run: |
+          set -euo pipefail
+          cd library/node/20
+          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+          sleep 5
+
+      - name: Wait for port 8080
+        run: |
+          set -euo pipefail
+          TIMEOUT=15
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              cat library/node/20/uk.pid | xargs kill || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            cat library/node/20/uk.pid | xargs kill || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup unikernel
+        if: always()
+        run: |
+          set -euo pipefail
+          cat library/node/20/uk.pid | xargs kill || true

--- a/.github/workflows/library-node20.yaml
+++ b/.github/workflows/library-node20.yaml
@@ -86,6 +86,7 @@ jobs:
     name: Test Node 20 (Remote OCI)
     needs: [build, push]
     runs-on: ubuntu-latest
+
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
@@ -94,52 +95,48 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Pull and start unikernel
-        id: start
+      - name: Pull, run, validate and cleanup remote container
         run: |
           set -euo pipefail
+
+          echo "Pull and start unikernel"
           IMAGE=index.unikraft.io/unikraft.org/node:20
           docker pull "$IMAGE"
           CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
-          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
 
-      - name: Wait for port 8080
-        run: |
-          set -euo pipefail
+          echo "Wait for port 8080"
           TIMEOUT=15
           START_TS=$(date +%s)
           until nc -z localhost 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
-              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 8080 is now accepting connections"
 
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
-            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup container
-        if: always()
-        run: |
-          set -euo pipefail
-          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
-
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
   run-local:
     name: Test Node 20 (Local build)
     needs: [build]
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -149,47 +146,41 @@ jobs:
           loglevel: debug
           runtimedir: /github/workspace/.kraftkit
 
-      - name: Build unikernel locally
-        run: |
-          cd library/node/20
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-      - name: Run local unikernel
+      - name: Build, run, validate and cleanup local unikernel
         run: |
           set -euo pipefail
           cd library/node/20
-          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+
+          echo "Build unikernel locally"
+          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run local unikernel"
+          sudo kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
           sleep 5
 
-      - name: Wait for port 8080
-        run: |
-          set -euo pipefail
+          echo "Wait for port 8080"
           TIMEOUT=15
           START_TS=$(date +%s)
           until nc -z localhost 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
-              cat library/node/20/uk.pid | xargs kill || true
+              sudo kill "$PID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 8080 is now accepting connections"
 
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
-            cat library/node/20/uk.pid | xargs kill || true
+            sudo kill "$PID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup unikernel
-        if: always()
-        run: |
-          set -euo pipefail
-          cat library/node/20/uk.pid | xargs kill || true
+          echo "Cleanup unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-node21.yaml
+++ b/.github/workflows/library-node21.yaml
@@ -176,7 +176,7 @@ jobs:
 
           echo "Validate HTTP response"
           EXPECTED="Hello, World!"
-          RESPONSE=$(curl -fs http://localhost:8080/)
+          RESPONSE=$(curl -fs http://localhost:8080/ | tr -d '\r\n')
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
             sudo kill "$PID" || true

--- a/.github/workflows/library-node21.yaml
+++ b/.github/workflows/library-node21.yaml
@@ -83,3 +83,115 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/node:21
         push: true
+
+  run-remote:
+    name: Test Node 21 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull and start unikernel
+        id: start
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/node:21
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait for port 8080
+        run: |
+          set -euo pipefail
+          TIMEOUT=15
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          set -euo pipefail
+          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+
+  run-local:
+    name: Test Node 21 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kraftkit
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          runtimedir: /github/workspace/.kraftkit
+
+      - name: Build unikernel locally
+        run: |
+          cd library/node/21
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+      - name: Run local unikernel
+        run: |
+          set -euo pipefail
+          cd library/node/21
+          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+          sleep 5
+
+      - name: Wait for port 8080
+        run: |
+          set -euo pipefail
+          TIMEOUT=15
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              cat library/node/21/uk.pid | xargs kill || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            cat library/node/21/uk.pid | xargs kill || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup unikernel
+        if: always()
+        run: |
+          set -euo pipefail
+          cat library/node/21/uk.pid | xargs kill || true

--- a/.github/workflows/library-node21.yaml
+++ b/.github/workflows/library-node21.yaml
@@ -88,6 +88,7 @@ jobs:
     name: Test Node 21 (Remote OCI)
     needs: [build, push]
     runs-on: ubuntu-latest
+
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
@@ -96,52 +97,48 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Pull and start unikernel
-        id: start
+      - name: Pull, run, validate and cleanup container
         run: |
           set -euo pipefail
+
+          echo "Pull and start unikernel"
           IMAGE=index.unikraft.io/unikraft.org/node:21
           docker pull "$IMAGE"
           CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
-          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
 
-      - name: Wait for port 8080
-        run: |
-          set -euo pipefail
+          echo "Wait for port 8080"
           TIMEOUT=15
           START_TS=$(date +%s)
           until nc -z localhost 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
-              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 8080 is now accepting connections"
 
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
-            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup container
-        if: always()
-        run: |
-          set -euo pipefail
-          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
 
   run-local:
     name: Test Node 21 (Local build)
     needs: [build]
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -151,47 +148,41 @@ jobs:
           loglevel: debug
           runtimedir: /github/workspace/.kraftkit
 
-      - name: Build unikernel locally
-        run: |
-          cd library/node/21
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-      - name: Run local unikernel
+      - name: Build, run, validate and cleanup local unikernel
         run: |
           set -euo pipefail
           cd library/node/21
-          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+
+          echo "Build unikernel locally"
+          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run local unikernel"
+          sudo kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
           sleep 5
 
-      - name: Wait for port 8080
-        run: |
-          set -euo pipefail
+          echo "Wait for port 8080"
           TIMEOUT=15
           START_TS=$(date +%s)
           until nc -z localhost 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
-              cat library/node/21/uk.pid | xargs kill || true
+              sudo kill "$PID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 8080 is now accepting connections"
 
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
-            cat library/node/21/uk.pid | xargs kill || true
+            sudo kill "$PID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup unikernel
-        if: always()
-        run: |
-          set -euo pipefail
-          cat library/node/21/uk.pid | xargs kill || true
+          echo "Cleanup unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-perl5.38.yaml
+++ b/.github/workflows/library-perl5.38.yaml
@@ -142,22 +142,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup kraftkit
-        uses: unikraft/kraftkit@staging
-        with:
-          loglevel: debug
-          runtimedir: /github/workspace/.kraftkit
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup local unikernel
+      - name: Build, run, validate and cleanup unikernel
         run: |
           set -euo pipefail
+          sudo chmod 666 /dev/kvm
           cd library/perl/5.38
 
-          echo "Build unikernel locally"
-          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+          echo "Build Perl 5.38 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
 
-          echo "Run local unikernel"
-          sudo kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
+          echo "Run Perl 5.38 unikernel"
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
 
@@ -184,5 +185,5 @@ jobs:
           fi
           echo "Response is correct: '$RESPONSE'"
 
-          echo "Cleanup unikernel"
+          echo "Cleanup Perl 5.38 unikernel"
           sudo kill "$PID" || true

--- a/.github/workflows/library-perl5.38.yaml
+++ b/.github/workflows/library-perl5.38.yaml
@@ -83,3 +83,113 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/perl:5.38
         push: true
+
+  run-remote:
+    name: Test Perl 5.38 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull and start unikernel
+        id: start
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/perl:5.38
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait for port 8080
+        run: |
+          set -euo pipefail
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          set -euo pipefail
+          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+
+  run-local:
+    name: Test Perl 5.38 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kraftkit
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          runtimedir: /github/workspace/.kraftkit
+
+      - name: Build unikernel locally
+        run: |
+          cd library/perl/5.38
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+      - name: Run local unikernel
+        run: |
+          set -euo pipefail
+          cd library/perl/5.38
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+          sleep 5
+
+      - name: Wait for port 8080
+        run: |
+          set -euo pipefail
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+      - name: Validate HTTP response
+        run: |
+          set -euo pipefail
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+      - name: Cleanup unikernel
+        if: always()
+        run: |
+          set -euo pipefail
+          cat library/perl/5.38/uk.pid | xargs kill || true

--- a/.github/workflows/library-perl5.38.yaml
+++ b/.github/workflows/library-perl5.38.yaml
@@ -88,6 +88,7 @@ jobs:
     name: Test Perl 5.38 (Remote OCI)
     needs: [build, push]
     runs-on: ubuntu-latest
+
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
@@ -96,52 +97,48 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Pull and start unikernel
-        id: start
+      - name: Pull, run, validate and cleanup remote container
         run: |
           set -euo pipefail
+
+          echo "Pull and start unikernel"
           IMAGE=index.unikraft.io/unikraft.org/perl:5.38
           docker pull "$IMAGE"
           CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
-          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
 
-      - name: Wait for port 8080
-        run: |
-          set -euo pipefail
+          echo "Wait for port 8080"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z localhost 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
-              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 8080 is now accepting connections"
 
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
-            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup container
-        if: always()
-        run: |
-          set -euo pipefail
-          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
 
   run-local:
     name: Test Perl 5.38 (Local build)
     needs: [build]
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -151,45 +148,41 @@ jobs:
           loglevel: debug
           runtimedir: /github/workspace/.kraftkit
 
-      - name: Build unikernel locally
-        run: |
-          cd library/perl/5.38
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-      - name: Run local unikernel
+      - name: Build, run, validate and cleanup local unikernel
         run: |
           set -euo pipefail
           cd library/perl/5.38
-          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+
+          echo "Build unikernel locally"
+          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run local unikernel"
+          sudo kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
           sleep 5
 
-      - name: Wait for port 8080
-        run: |
-          set -euo pipefail
+          echo "Wait for port 8080"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z localhost 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
               exit 1
             fi
             sleep 1
           done
           echo "Port 8080 is now accepting connections"
 
-      - name: Validate HTTP response
-        run: |
-          set -euo pipefail
+          echo "Validate HTTP response"
           EXPECTED="Hello, World!"
           RESPONSE=$(curl -fs http://localhost:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
             exit 1
           fi
           echo "Response is correct: '$RESPONSE'"
 
-      - name: Cleanup unikernel
-        if: always()
-        run: |
-          set -euo pipefail
-          cat library/perl/5.38/uk.pid | xargs kill || true
+          echo "Cleanup unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-perl5.38.yaml
+++ b/.github/workflows/library-perl5.38.yaml
@@ -177,7 +177,7 @@ jobs:
 
           echo "Validate HTTP response"
           EXPECTED="Hello, World!"
-          RESPONSE=$(curl -fs http://localhost:8080/)
+          RESPONSE=$(curl -fs http://localhost:8080/ | tr -d '\r\n')
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
             sudo kill "$PID" || true

--- a/.github/workflows/library-python3.10.yaml
+++ b/.github/workflows/library-python3.10.yaml
@@ -137,10 +137,10 @@ jobs:
 
           echo "Build Python 3.10 unikernel"
           kraft clean
-          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+          kraft build --no-cache --no-update --plat qemu --arch x86_64 --target python@qemu/x86_64
 
           echo "Run local unikernel"
-          sudo kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 --target python@qemu/x86_64 . &
           PID=$!
           sleep 5
 

--- a/.github/workflows/library-python3.10.yaml
+++ b/.github/workflows/library-python3.10.yaml
@@ -130,7 +130,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y kraftkit
 
-      - name: Build, run and validate Python 3.10 unikernel
+      - name: Build, run and validate unikernel
         run: |
           set -euo pipefail
           sudo chmod 666 /dev/kvm
@@ -144,5 +144,7 @@ jobs:
           PID=$!
           sleep 5
 
-
           echo "Python 3.10 unikernel started successfully locally"
+
+          echo "Cleanup Python 3.10 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-python3.10.yaml
+++ b/.github/workflows/library-python3.10.yaml
@@ -133,6 +133,7 @@ jobs:
       - name: Build, run, validate and cleanup Python 3.10 unikernel
         run: |
           set -euo pipefail
+          sudo chmod 666 /dev/kvm
           cd library/python/3.10
 
           echo "Build Python 3.10 unikernel"

--- a/.github/workflows/library-python3.10.yaml
+++ b/.github/workflows/library-python3.10.yaml
@@ -94,36 +94,33 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Pull and start unikernel
-        id: start
+      - name: Pull, run, validate and cleanup unikernel
         run: |
           set -euo pipefail
+
+          echo "Pull and start Python 3.10 unikernel"
           IMAGE=index.unikraft.io/unikraft.org/python:3.10
           docker pull "$IMAGE"
           CONTAINER_ID=$(docker run --rm -d "$IMAGE")
-          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
 
-      - name: Validate unikernel startup
-        run: |
-          set -euo pipefail
+          echo "Wait and validate container startup"
           sleep 5
-          if ! docker ps --filter "id=${{ steps.start.outputs.CONTAINER_ID }}" --format '{{.ID}}' | grep -q .; then
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
             echo "ERROR: Python 3.10 unikernel is not running" >&2
-            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
             exit 1
           fi
           echo "Python 3.10 unikernel started successfully"
 
-      - name: Cleanup container
-        if: always()
-        run: |
-          set -euo pipefail
-          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
-
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
   run-local:
     name: Test Python 3.10 (Local build)
     needs: [build]
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -133,29 +130,26 @@ jobs:
           loglevel: debug
           runtimedir: /github/workspace/.kraftkit
 
-      - name: Build unikernel locally
-        run: |
-          cd library/python/3.10
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-      - name: Run local unikernel
+      - name: Build, run, validate and cleanup locally
         run: |
           set -euo pipefail
           cd library/python/3.10
-          kraft run --rm -M 256M --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+
+          echo "Build Python 3.10 unikernel"
+          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run local unikernel"
+          sudo kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
           sleep 5
 
-      - name: Validate unikernel startup
-        run: |
-          set -euo pipefail
-          if ! ps -p $(cat library/python/3.10/uk.pid) > /dev/null; then
+          echo "Validate local process startup"
+          if ! ps -p "$PID" > /dev/null; then
             echo "ERROR: Python 3.10 unikernel failed to start locally" >&2
+            sudo kill "$PID" || true
             exit 1
           fi
           echo "Python 3.10 unikernel started successfully locally"
 
-      - name: Cleanup unikernel
-        if: always()
-        run: |
-          set -euo pipefail
-          cat library/python/3.10/uk.pid | xargs kill || true
+          echo "Cleanup local unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-python3.10.yaml
+++ b/.github/workflows/library-python3.10.yaml
@@ -137,10 +137,10 @@ jobs:
 
           echo "Build Python 3.10 unikernel"
           kraft clean
-          kraft build --no-cache --no-update --plat qemu --arch x86_64 --target python@qemu/x86_64
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
 
           echo "Run local unikernel"
-          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 --target python@qemu/x86_64 . &
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
 

--- a/.github/workflows/library-python3.10.yaml
+++ b/.github/workflows/library-python3.10.yaml
@@ -124,18 +124,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup kraftkit
-        uses: unikraft/kraftkit@staging
-        with:
-          loglevel: debug
-          runtimedir: /github/workspace/.kraftkit
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup locally
+      - name: Build, run, validate and cleanup Python 3.10 unikernel
         run: |
           set -euo pipefail
           cd library/python/3.10
 
           echo "Build Python 3.10 unikernel"
+          kraft clean
           sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
 
           echo "Run local unikernel"

--- a/.github/workflows/library-python3.10.yaml
+++ b/.github/workflows/library-python3.10.yaml
@@ -81,3 +81,81 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/python:3.10
         push: true
+
+  run-remote:
+    name: Test Python 3.10 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull and start unikernel
+        id: start
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/python:3.10
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
+
+      - name: Validate unikernel startup
+        run: |
+          set -euo pipefail
+          sleep 5
+          if ! docker ps --filter "id=${{ steps.start.outputs.CONTAINER_ID }}" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: Python 3.10 unikernel is not running" >&2
+            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            exit 1
+          fi
+          echo "Python 3.10 unikernel started successfully"
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          set -euo pipefail
+          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+
+  run-local:
+    name: Test Python 3.10 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kraftkit
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          runtimedir: /github/workspace/.kraftkit
+
+      - name: Build unikernel locally
+        run: |
+          cd library/python/3.10
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+      - name: Run local unikernel
+        run: |
+          set -euo pipefail
+          cd library/python/3.10
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+          sleep 5
+
+      - name: Validate unikernel startup
+        run: |
+          set -euo pipefail
+          if ! ps -p $(cat library/python/3.10/uk.pid) > /dev/null; then
+            echo "ERROR: Python 3.10 unikernel failed to start locally" >&2
+            exit 1
+          fi
+          echo "Python 3.10 unikernel started successfully locally"
+
+      - name: Cleanup unikernel
+        if: always()
+        run: |
+          set -euo pipefail
+          cat library/python/3.10/uk.pid | xargs kill || true

--- a/.github/workflows/library-python3.10.yaml
+++ b/.github/workflows/library-python3.10.yaml
@@ -139,7 +139,7 @@ jobs:
           kraft build --no-cache --no-update --plat qemu --arch x86_64
   
           echo "Run Python 3.10 unikernel"
-          kraft run --rm -M 256M --plat qemu --arch x86_64 
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
 

--- a/.github/workflows/library-python3.10.yaml
+++ b/.github/workflows/library-python3.10.yaml
@@ -130,7 +130,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup Python 3.10 unikernel
+      - name: Build, run and validate Python 3.10 unikernel
         run: |
           set -euo pipefail
           sudo chmod 666 /dev/kvm
@@ -144,13 +144,5 @@ jobs:
           PID=$!
           sleep 5
 
-          echo "Validate local process startup"
-          if ! ps -p "$PID" > /dev/null; then
-            echo "ERROR: Python 3.10 unikernel failed to start locally" >&2
-            sudo kill "$PID" || true
-            exit 1
-          fi
-          echo "Python 3.10 unikernel started successfully locally"
 
-          echo "Cleanup local unikernel"
-          sudo kill "$PID" || true
+          echo "Python 3.10 unikernel started successfully locally"

--- a/.github/workflows/library-python3.10.yaml
+++ b/.github/workflows/library-python3.10.yaml
@@ -136,11 +136,10 @@ jobs:
           cd library/python/3.10
 
           echo "Build Python 3.10 unikernel"
-          kraft clean
           kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-          echo "Run local unikernel"
-          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+  
+          echo "Run Python 3.10 unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 
           PID=$!
           sleep 5
 

--- a/.github/workflows/library-python3.12.yaml
+++ b/.github/workflows/library-python3.12.yaml
@@ -139,26 +139,26 @@ jobs:
           kraft build --no-cache --no-update --plat qemu --arch x86_64
   
           echo "Run Python 3.12 unikernel"
-          kraft run --rm -M 256M -p 3000:3000 --plat qemu --arch x86_64 &
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 
           PID=$!
           sleep 5
   
-          echo "Wait for port 3000"
+          echo "Wait for port 8080"
           TIMEOUT=10
           START_TS=$(date +%s)
-          until nc -z localhost 3000; do
+          until nc -z localhost 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
-              echo "ERROR: port 3000 did not open within ${TIMEOUT}s" >&2
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
               sudo kill "$PID" || true
               exit 1
             fi
             sleep 1
           done
-          echo "Port 3000 is now accepting connections"
+          echo "Port 8080 is now accepting connections"
   
           echo "Validate HTTP response"
           EXPECTED="Hello, World!"
-          RESPONSE=$(curl -fs http://localhost:3000/)
+          RESPONSE=$(curl -fs http://localhost:8080/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
             sudo kill "$PID" || true

--- a/.github/workflows/library-python3.12.yaml
+++ b/.github/workflows/library-python3.12.yaml
@@ -81,3 +81,81 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/python:3.12
         push: true
+
+  run-remote:
+    name: Test Python 3.12 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull and start unikernel
+        id: start
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/python:3.12
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
+
+      - name: Validate unikernel startup
+        run: |
+          set -euo pipefail
+          sleep 5
+          if ! docker ps --filter "id=${{ steps.start.outputs.CONTAINER_ID }}" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: Python 3.12 unikernel is not running" >&2
+            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            exit 1
+          fi
+          echo "Python 3.12 unikernel started successfully"
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          set -euo pipefail
+          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+
+  run-local:
+    name: Test Python 3.12 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kraftkit
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          runtimedir: /github/workspace/.kraftkit
+
+      - name: Build unikernel locally
+        run: |
+          cd library/python/3.12
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+      - name: Run local unikernel
+        run: |
+          set -euo pipefail
+          cd library/python/3.12
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+          sleep 5
+
+      - name: Validate unikernel startup
+        run: |
+          set -euo pipefail
+          if ! ps -p $(cat library/python/3.12/uk.pid) > /dev/null; then
+            echo "ERROR: Python 3.12 unikernel failed to start locally" >&2
+            exit 1
+          fi
+          echo "Python 3.12 unikernel started successfully locally"
+
+      - name: Cleanup unikernel
+        if: always()
+        run: |
+          set -euo pipefail
+          cat library/python/3.12/uk.pid | xargs kill || true

--- a/.github/workflows/library-python3.12.yaml
+++ b/.github/workflows/library-python3.12.yaml
@@ -135,12 +135,11 @@ jobs:
           sudo chmod 666 /dev/kvm
           cd library/python/3.12
   
-          echo "Clean and build Python 3.12 unikernel"
-          kraft clean
-          kraft build python@qemu/x86_64 --no-cache --no-update
+          echo "Build Python 3.12 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
   
           echo "Run Python 3.12 unikernel"
-          kraft run python@qemu/x86_64 --rm -M 256M -p 8080:8080 &
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 
           PID=$!
           sleep 5
   

--- a/.github/workflows/library-python3.12.yaml
+++ b/.github/workflows/library-python3.12.yaml
@@ -123,32 +123,48 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup kraftkit
-        uses: unikraft/kraftkit@staging
-        with:
-          loglevel: debug
-          runtimedir: /github/workspace/.kraftkit
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup locally
+      - name: Build, run, validate and cleanup Python 3.12 unikernel
         run: |
           set -euo pipefail
+          sudo chmod 666 /dev/kvm
           cd library/python/3.12
-
+  
           echo "Build Python 3.12 unikernel"
-          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-          echo "Run Python 3.12 locally"
-          sudo kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run Python 3.12 unikernel"
+          kraft run --rm -M 256M -p 3000:3000 --plat qemu --arch x86_64 &
           PID=$!
           sleep 5
-
-          echo "Validate local process startup"
-          if ! ps -p "$PID" > /dev/null; then
-            echo "ERROR: Python 3.12 unikernel failed to start locally" >&2
+  
+          echo "Wait for port 3000"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 3000; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 3000 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 3000 is now accepting connections"
+  
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:3000/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
             sudo kill "$PID" || true
             exit 1
           fi
-          echo "Python 3.12 unikernel started successfully locally"
-
-          echo "Cleanup local unikernel"
+          echo "Response is correct: '$RESPONSE'"
+  
+          echo "Cleanup Python 3.12 unikernel"
           sudo kill "$PID" || true

--- a/.github/workflows/library-python3.12.yaml
+++ b/.github/workflows/library-python3.12.yaml
@@ -137,10 +137,10 @@ jobs:
   
           echo "Build Python 3.12 unikernel"
           kraft clean
-          kraft build --no-cache --no-update --plat qemu --arch x86_64 --target python@qemu/x86_64
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
   
           echo "Run Python 3.12 unikernel"
-          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 --target python@qemu/x86_64 . &
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
   

--- a/.github/workflows/library-python3.12.yaml
+++ b/.github/workflows/library-python3.12.yaml
@@ -94,31 +94,27 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Pull and start unikernel
-        id: start
+      - name: Pull, run, validate and cleanup unikernel
         run: |
           set -euo pipefail
+
+          echo "Pull and start Python 3.12 unikernel"
           IMAGE=index.unikraft.io/unikraft.org/python:3.12
           docker pull "$IMAGE"
           CONTAINER_ID=$(docker run --rm -d "$IMAGE")
-          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
 
-      - name: Validate unikernel startup
-        run: |
-          set -euo pipefail
+          echo "Wait and validate container startup"
           sleep 5
-          if ! docker ps --filter "id=${{ steps.start.outputs.CONTAINER_ID }}" --format '{{.ID}}' | grep -q .; then
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
             echo "ERROR: Python 3.12 unikernel is not running" >&2
-            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
             exit 1
           fi
           echo "Python 3.12 unikernel started successfully"
 
-      - name: Cleanup container
-        if: always()
-        run: |
-          set -euo pipefail
-          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
 
   run-local:
     name: Test Python 3.12 (Local build)
@@ -133,29 +129,26 @@ jobs:
           loglevel: debug
           runtimedir: /github/workspace/.kraftkit
 
-      - name: Build unikernel locally
-        run: |
-          cd library/python/3.12
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-      - name: Run local unikernel
+      - name: Build, run, validate and cleanup locally
         run: |
           set -euo pipefail
           cd library/python/3.12
-          kraft run --rm -M 256M --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+
+          echo "Build Python 3.12 unikernel"
+          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run Python 3.12 locally"
+          sudo kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
           sleep 5
 
-      - name: Validate unikernel startup
-        run: |
-          set -euo pipefail
-          if ! ps -p $(cat library/python/3.12/uk.pid) > /dev/null; then
+          echo "Validate local process startup"
+          if ! ps -p "$PID" > /dev/null; then
             echo "ERROR: Python 3.12 unikernel failed to start locally" >&2
+            sudo kill "$PID" || true
             exit 1
           fi
           echo "Python 3.12 unikernel started successfully locally"
 
-      - name: Cleanup unikernel
-        if: always()
-        run: |
-          set -euo pipefail
-          cat library/python/3.12/uk.pid | xargs kill || true
+          echo "Cleanup local unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-python3.12.yaml
+++ b/.github/workflows/library-python3.12.yaml
@@ -139,7 +139,7 @@ jobs:
           kraft build --no-cache --no-update --plat qemu --arch x86_64
   
           echo "Run Python 3.12 unikernel"
-          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
   

--- a/.github/workflows/library-python3.12.yaml
+++ b/.github/workflows/library-python3.12.yaml
@@ -135,12 +135,12 @@ jobs:
           sudo chmod 666 /dev/kvm
           cd library/python/3.12
   
-          echo "Build Python 3.12 unikernel"
+          echo "Clean and build Python 3.12 unikernel"
           kraft clean
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
+          kraft build python@qemu/x86_64 --no-cache --no-update
   
           echo "Run Python 3.12 unikernel"
-          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
+          kraft run python@qemu/x86_64 --rm -M 256M -p 8080:8080 &
           PID=$!
           sleep 5
   

--- a/.github/workflows/library-python3.12.yaml
+++ b/.github/workflows/library-python3.12.yaml
@@ -136,10 +136,11 @@ jobs:
           cd library/python/3.12
   
           echo "Build Python 3.12 unikernel"
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
+          kraft clean
+          kraft build --no-cache --no-update --plat qemu --arch x86_64 --target python@qemu/x86_64
   
           echo "Run Python 3.12 unikernel"
-          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 --target python@qemu/x86_64 . &
           PID=$!
           sleep 5
   

--- a/.github/workflows/library-python3.12.yaml
+++ b/.github/workflows/library-python3.12.yaml
@@ -129,7 +129,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup Python 3.12 unikernel
+      - name: Build, run, validate and cleanup unikernel
         run: |
           set -euo pipefail
           sudo chmod 666 /dev/kvm
@@ -139,7 +139,7 @@ jobs:
           kraft build --no-cache --no-update --plat qemu --arch x86_64
   
           echo "Run Python 3.12 unikernel"
-          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
   

--- a/.github/workflows/library-python3.13.yaml
+++ b/.github/workflows/library-python3.13.yaml
@@ -134,10 +134,10 @@ jobs:
 
           echo "Clean and build Python 3.13 unikernel"
           kraft clean
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
+          kraft build --no-cache --no-update --plat qemu --arch x86_64 --target python@qemu/x86_64
 
           echo "Run Python 3.13 unikernel"
-          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 --target python@qemu/x86_64 . &
           PID=$!
           sleep 5
 

--- a/.github/workflows/library-python3.13.yaml
+++ b/.github/workflows/library-python3.13.yaml
@@ -76,3 +76,81 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/python:3.13
         push: true
+
+  run-remote:
+    name: Test Python 3.13 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull and start unikernel
+        id: start
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/python:3.13
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
+
+      - name: Validate unikernel startup
+        run: |
+          set -euo pipefail
+          sleep 5
+          if ! docker ps --filter "id=${{ steps.start.outputs.CONTAINER_ID }}" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: Python 3.13 unikernel is not running" >&2
+            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            exit 1
+          fi
+          echo "Python 3.13 unikernel started successfully"
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          set -euo pipefail
+          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+
+  run-local:
+    name: Test Python 3.13 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kraftkit
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          runtimedir: /github/workspace/.kraftkit
+
+      - name: Build unikernel locally
+        run: |
+          cd library/python/3.13
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+      - name: Run local unikernel
+        run: |
+          set -euo pipefail
+          cd library/python/3.13
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+          sleep 5
+
+      - name: Validate unikernel startup
+        run: |
+          set -euo pipefail
+          if ! ps -p $(cat library/python/3.13/uk.pid) > /dev/null; then
+            echo "ERROR: Python 3.13 unikernel failed to start locally" >&2
+            exit 1
+          fi
+          echo "Python 3.13 unikernel started successfully locally"
+
+      - name: Cleanup unikernel
+        if: always()
+        run: |
+          set -euo pipefail
+          cat library/python/3.13/uk.pid | xargs kill || true

--- a/.github/workflows/library-python3.13.yaml
+++ b/.github/workflows/library-python3.13.yaml
@@ -126,7 +126,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup Python 3.13 unikernel
+      - name: Build, run, validate and cleanup unikernel
         run: |
           set -euo pipefail
           sudo chmod 666 /dev/kvm

--- a/.github/workflows/library-python3.13.yaml
+++ b/.github/workflows/library-python3.13.yaml
@@ -132,12 +132,11 @@ jobs:
           sudo chmod 666 /dev/kvm
           cd library/python/3.13
 
-          echo "Clean and build Python 3.13 unikernel"
-          kraft clean
+          echo "Build Python 3.13 unikernel"
           kraft build --no-cache --no-update --plat qemu --arch x86_64
-
+  
           echo "Run Python 3.13 unikernel"
-          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 
           PID=$!
           sleep 5
 

--- a/.github/workflows/library-python3.13.yaml
+++ b/.github/workflows/library-python3.13.yaml
@@ -134,10 +134,10 @@ jobs:
 
           echo "Clean and build Python 3.13 unikernel"
           kraft clean
-          kraft build --no-cache --no-update --plat qemu --arch x86_64 --target python@qemu/x86_64
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
 
           echo "Run Python 3.13 unikernel"
-          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 --target python@qemu/x86_64 . &
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
 

--- a/.github/workflows/library-python3.13.yaml
+++ b/.github/workflows/library-python3.13.yaml
@@ -136,7 +136,7 @@ jobs:
           kraft build --no-cache --no-update --plat qemu --arch x86_64
   
           echo "Run Python 3.13 unikernel"
-          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
 

--- a/.github/workflows/library-python3.13.yaml
+++ b/.github/workflows/library-python3.13.yaml
@@ -120,32 +120,49 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup kraftkit
-        uses: unikraft/kraftkit@staging
-        with:
-          loglevel: debug
-          runtimedir: /github/workspace/.kraftkit
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
 
-      - name: Build, run, validate and cleanup locally
+      - name: Build, run, validate and cleanup Python 3.13 unikernel
         run: |
           set -euo pipefail
+          sudo chmod 666 /dev/kvm
           cd library/python/3.13
 
-          echo "Build Python 3.13 unikernel"
-          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+          echo "Clean and build Python 3.13 unikernel"
+          kraft clean
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
 
-          echo "Run local unikernel"
-          sudo kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          echo "Run Python 3.13 unikernel"
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
 
-          echo "Validate local process startup"
-          if ! ps -p "$PID" > /dev/null; then
-            echo "ERROR: Python 3.13 unikernel failed to start locally" >&2
+          echo "Wait for port 8080"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
             sudo kill "$PID" || true
             exit 1
           fi
-          echo "Python 3.13 unikernel started successfully locally"
+          echo "Response is correct: '$RESPONSE'"
 
-          echo "Cleanup local unikernel"
+          echo "Cleanup Python 3.13 unikernel"
           sudo kill "$PID" || true

--- a/.github/workflows/library-python3.13.yaml
+++ b/.github/workflows/library-python3.13.yaml
@@ -81,6 +81,7 @@ jobs:
     name: Test Python 3.13 (Remote OCI)
     needs: [build, push]
     runs-on: ubuntu-latest
+
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
@@ -89,36 +90,33 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Pull and start unikernel
-        id: start
+      - name: Pull, run, validate and cleanup unikernel
         run: |
           set -euo pipefail
+
+          echo "Pull and start Python 3.13 unikernel"
           IMAGE=index.unikraft.io/unikraft.org/python:3.13
           docker pull "$IMAGE"
           CONTAINER_ID=$(docker run --rm -d "$IMAGE")
-          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
 
-      - name: Validate unikernel startup
-        run: |
-          set -euo pipefail
+          echo "Wait and validate container startup"
           sleep 5
-          if ! docker ps --filter "id=${{ steps.start.outputs.CONTAINER_ID }}" --format '{{.ID}}' | grep -q .; then
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
             echo "ERROR: Python 3.13 unikernel is not running" >&2
-            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
             exit 1
           fi
           echo "Python 3.13 unikernel started successfully"
 
-      - name: Cleanup container
-        if: always()
-        run: |
-          set -euo pipefail
-          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
 
   run-local:
     name: Test Python 3.13 (Local build)
     needs: [build]
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -128,29 +126,26 @@ jobs:
           loglevel: debug
           runtimedir: /github/workspace/.kraftkit
 
-      - name: Build unikernel locally
-        run: |
-          cd library/python/3.13
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-      - name: Run local unikernel
+      - name: Build, run, validate and cleanup locally
         run: |
           set -euo pipefail
           cd library/python/3.13
-          kraft run --rm -M 256M --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+
+          echo "Build Python 3.13 unikernel"
+          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run local unikernel"
+          sudo kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
           sleep 5
 
-      - name: Validate unikernel startup
-        run: |
-          set -euo pipefail
-          if ! ps -p $(cat library/python/3.13/uk.pid) > /dev/null; then
+          echo "Validate local process startup"
+          if ! ps -p "$PID" > /dev/null; then
             echo "ERROR: Python 3.13 unikernel failed to start locally" >&2
+            sudo kill "$PID" || true
             exit 1
           fi
           echo "Python 3.13 unikernel started successfully locally"
 
-      - name: Cleanup unikernel
-        if: always()
-        run: |
-          set -euo pipefail
-          cat library/python/3.13/uk.pid | xargs kill || true
+          echo "Cleanup local unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-redis7.2.yaml
+++ b/.github/workflows/library-redis7.2.yaml
@@ -146,7 +146,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y kraftkit redis-tools
 
-      - name: Build, run, ping, and cleanup Redis 7.2 unikernel
+      - name: Build, run, ping, and cleanup unikernel
         run: |
           set -euo pipefail
           sudo chmod 666 /dev/kvm

--- a/.github/workflows/library-redis7.2.yaml
+++ b/.github/workflows/library-redis7.2.yaml
@@ -86,6 +86,7 @@ jobs:
     name: Test Redis 7.2 (Remote OCI)
     needs: [build, push]
     runs-on: ubuntu-latest
+
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
@@ -94,46 +95,48 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Pull and start unikernel
-        id: start
+      - name: Pull, run, ping, and cleanup remote unikernel
         run: |
           set -euo pipefail
+
+          echo "Pull and start Redis unikernel"
           IMAGE=index.unikraft.io/unikraft.org/redis:7.2
           docker pull "$IMAGE"
           CONTAINER_ID=$(docker run --rm -d -p 6379:6379 "$IMAGE")
-          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
 
-      - name: Test Redis PING
-        run: |
-          set -euo pipefail
+          echo "Install redis-cli"
           sudo apt-get update -y && sudo apt-get install -y redis-tools
+
+          echo "Wait for port 6379"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z localhost 6379; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: Redis port 6379 did not open within ${TIMEOUT}s" >&2
-              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
               exit 1
             fi
             sleep 1
           done
+
+          echo "Send PING to Redis"
           if ! redis-cli -h 127.0.0.1 -p 6379 ping | grep -q "PONG"; then
             echo "ERROR: Redis did not respond to PING" >&2
-            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
             exit 1
           fi
           echo "Redis 7.2 unikernel responded to PING with PONG"
 
-      - name: Cleanup container
-        if: always()
-        run: |
-          set -euo pipefail
-          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
-
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+  
   run-local:
     name: Test Redis 7.2 (Local build)
     needs: [build]
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -143,39 +146,41 @@ jobs:
           loglevel: debug
           runtimedir: /github/workspace/.kraftkit
 
-      - name: Build unikernel locally
-        run: |
-          cd library/redis/7.2
-          kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-      - name: Run local unikernel
+      - name: Build, run, ping, and cleanup local unikernel
         run: |
           set -euo pipefail
           cd library/redis/7.2
-          kraft run --rm -M 256M -p 6379:6379 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+
+          echo "Build unikernel locally"
+          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run local Redis unikernel"
+          sudo kraft run --rm -M 256M -p 6379:6379 --plat qemu --arch x86_64 . &
+          PID=$!
           sleep 5
 
-      - name: Test Redis PING
-        run: |
-          set -euo pipefail
+          echo "Install redis-cli"
           sudo apt-get update -y && sudo apt-get install -y redis-tools
+
+          echo "Wait for port 6379"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z localhost 6379; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
               echo "ERROR: Redis port 6379 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
               exit 1
             fi
             sleep 1
           done
+
+          echo "Send PING to Redis"
           if ! redis-cli -h 127.0.0.1 -p 6379 ping | grep -q "PONG"; then
             echo "ERROR: Redis did not respond to PING" >&2
+            sudo kill "$PID" || true
             exit 1
           fi
           echo "Redis 7.2 local unikernel responded to PING with PONG"
 
-      - name: Cleanup unikernel
-        if: always()
-        run: |
-          set -euo pipefail
-          cat library/redis/7.2/uk.pid | xargs kill || true
+          echo "Cleanup unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-redis7.2.yaml
+++ b/.github/workflows/library-redis7.2.yaml
@@ -140,27 +140,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup kraftkit
-        uses: unikraft/kraftkit@staging
-        with:
-          loglevel: debug
-          runtimedir: /github/workspace/.kraftkit
+      - name: Install kraft CLI and redis-tools
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit redis-tools
 
-      - name: Build, run, ping, and cleanup local unikernel
+      - name: Build, run, ping, and cleanup Redis 7.2 unikernel
         run: |
           set -euo pipefail
+          sudo chmod 666 /dev/kvm
           cd library/redis/7.2
 
-          echo "Build unikernel locally"
-          sudo kraft build --no-cache --no-update --plat qemu --arch x86_64
+          echo "Build Redis 7.2 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
 
-          echo "Run local Redis unikernel"
-          sudo kraft run --rm -M 256M -p 6379:6379 --plat qemu --arch x86_64 . &
+          echo "Run Redis 7.2 unikernel"
+          kraft run --rm -M 256M -p 6379:6379 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
-
-          echo "Install redis-cli"
-          sudo apt-get update -y && sudo apt-get install -y redis-tools
 
           echo "Wait for port 6379"
           TIMEOUT=10
@@ -173,14 +171,15 @@ jobs:
             fi
             sleep 1
           done
+          echo "Redis is now accepting connections on port 6379"
 
-          echo "Send PING to Redis"
+          echo "Validate Redis PING"
           if ! redis-cli -h 127.0.0.1 -p 6379 ping | grep -q "PONG"; then
             echo "ERROR: Redis did not respond to PING" >&2
             sudo kill "$PID" || true
             exit 1
           fi
-          echo "Redis 7.2 local unikernel responded to PING with PONG"
+          echo "Redis 7.2 responded correctly to PING"
 
-          echo "Cleanup unikernel"
+          echo "Cleanup Redis 7.2 unikernel"
           sudo kill "$PID" || true

--- a/.github/workflows/library-redis7.2.yaml
+++ b/.github/workflows/library-redis7.2.yaml
@@ -81,3 +81,101 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/redis:7.2
         push: true
+
+  run-remote:
+    name: Test Redis 7.2 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull and start unikernel
+        id: start
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/redis:7.2
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 6379:6379 "$IMAGE")
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
+
+      - name: Test Redis PING
+        run: |
+          set -euo pipefail
+          sudo apt-get update -y && sudo apt-get install -y redis-tools
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 6379; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: Redis port 6379 did not open within ${TIMEOUT}s" >&2
+              docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+          if ! redis-cli -h 127.0.0.1 -p 6379 ping | grep -q "PONG"; then
+            echo "ERROR: Redis did not respond to PING" >&2
+            docker logs "${{ steps.start.outputs.CONTAINER_ID }}" >&2 || true
+            exit 1
+          fi
+          echo "Redis 7.2 unikernel responded to PING with PONG"
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          set -euo pipefail
+          docker stop "${{ steps.start.outputs.CONTAINER_ID }}" || true
+
+  run-local:
+    name: Test Redis 7.2 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kraftkit
+        uses: unikraft/kraftkit@staging
+        with:
+          loglevel: debug
+          runtimedir: /github/workspace/.kraftkit
+
+      - name: Build unikernel locally
+        run: |
+          cd library/redis/7.2
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+      - name: Run local unikernel
+        run: |
+          set -euo pipefail
+          cd library/redis/7.2
+          kraft run --rm -M 256M -p 6379:6379 --plat qemu --arch x86_64 . & echo "$!" > uk.pid
+          sleep 5
+
+      - name: Test Redis PING
+        run: |
+          set -euo pipefail
+          sudo apt-get update -y && sudo apt-get install -y redis-tools
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 6379; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: Redis port 6379 did not open within ${TIMEOUT}s" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          if ! redis-cli -h 127.0.0.1 -p 6379 ping | grep -q "PONG"; then
+            echo "ERROR: Redis did not respond to PING" >&2
+            exit 1
+          fi
+          echo "Redis 7.2 local unikernel responded to PING with PONG"
+
+      - name: Cleanup unikernel
+        if: always()
+        run: |
+          set -euo pipefail
+          cat library/redis/7.2/uk.pid | xargs kill || true


### PR DESCRIPTION
#### Summary

This PR updates the GitHub Actions workflows for the following Unikraft library packages:
- `bun:1.1`
- `caddy:2.7`
- `lua:5.4`, `lua:5.4.4`
- `node:18`, `node:19`, `node:20`, `node:21`
- `perl:5.38`
- `python:3.10`, `python:3.12`, `python:3.13`
- `redis:7.2`

The added test jobs (`run-local` and `run-remote`) are designed based on the usage and behavior documented in each library's corresponding `README.md` file. They follow the examples and expected outputs provided, such as HTTP responses (`"Hello, World!"`) or CLI commands (e.g., `redis-cli ping`), to ensure functional correctness of each unikernel.

Each workflow now includes:
- A `run-local` job to build and test the unikernel locally using QEMU.
- A `run-remote` job to pull the OCI image and test it using Docker.

#### Motivation

Adding both local and remote test steps ensures:
- Unikernels build and run correctly in a local QEMU environment.
- Published OCI images are validated and function as expected in containerized environments.

These improvements help detect issues earlier in the pipeline and increase confidence in the correctness of released artifacts.

#### Checklist

- [x] Read the contribution guidelines at https://unikraft.org/docs/contributing/unikraft  
- [ ] Test changes against relevant architectures and platforms  
- [ ] Run `checkpatch.pl` on commit series before opening the PR  
- [ ] Update relevant documentation (if applicable)  
