### PR TITLE
Add local and remote test jobs for Unikraft library unikernels

### DIFF
--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -155,26 +155,26 @@ jobs:
           kraft build --no-cache --no-update --plat qemu --arch x86_64
 
           echo "Run local unikernel"
-          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
+          kraft run --rm -M 256M -p 3000:3000 --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
       
-          echo "Wait for port 8080"
+          echo "Wait for port 3000"
           TIMEOUT=10
           START_TS=$(date +%s)
           until nc -z localhost 8080; do
             if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
-              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              echo "ERROR: port 3000 did not open within ${TIMEOUT}s" >&2
               sudo kill "$PID" || true
               exit 1
             fi
             sleep 1
           done
-          echo "Port 8080 is now accepting connections"
+          echo "Port 3000 is now accepting connections"
       
           echo "Validate HTTP response"
           EXPECTED="Hello, World!"
-          RESPONSE=$(curl -fs http://localhost:8080/)
+          RESPONSE=$(curl -fs http://localhost:3000/)
           if [ "$RESPONSE" != "$EXPECTED" ]; then
             echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
             sudo kill "$PID" || true

--- a/.github/workflows/library-bun1.1.yaml
+++ b/.github/workflows/library-bun1.1.yaml
@@ -78,3 +78,109 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/bun:1.1
         push: true
+
+  run-remote:
+    name: Test Bun 1.1 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup remote container
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/bun:1.1
+
+          echo "Pulling remote OCI image..."
+          docker pull "$IMAGE"
+
+          echo "Starting remote unikernel container..."
+          CONTAINER_ID=$(docker run --rm -d -p 3000:3000 "$IMAGE")
+
+          echo "Waiting for port 3000"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 3000; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 3000 did not open within ${TIMEOUT}s" >&2
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 3000 is now accepting connections"
+
+          echo "Validating HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:3000/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Stopping container"
+          docker stop "$CONTAINER_ID" || true
+
+  run-local:
+    name: Test Bun 1.1 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+
+      - name: Build, run, validate and cleanup local unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/bun/1.1
+      
+          echo "Build unikernel locally"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run local unikernel"
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+      
+          echo "Wait for port 8080"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+      
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+      
+          echo "Cleanup unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-caddy2.7.yaml
+++ b/.github/workflows/library-caddy2.7.yaml
@@ -83,3 +83,109 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/caddy:2.7
         push: true
+
+  run-remote:
+    name: Test Caddy 2.7 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup remote container
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/caddy:2.7
+
+          echo "Pulling remote OCI image..."
+          docker pull "$IMAGE"
+
+          echo "Starting remote unikernel container..."
+          CONTAINER_ID=$(docker run --rm -d -p 2015:2015 "$IMAGE")
+
+          echo "Waiting for port 2015"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 2015; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 2015 did not open within ${TIMEOUT}s" >&2
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 2015 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:2015/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Stopping container"
+          docker stop "$CONTAINER_ID" || true
+
+  run-local:
+    name: Test Caddy 2.7 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+
+      - name: Build, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/caddy/2.7
+
+          echo "Build Caddy 2.7 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run Caddy 2.7 unikernel"
+          kraft run --rm -M 512M -p 2015:2015 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "Wait for port 2015"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 2015; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 2015 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 2015 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:2015/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup Caddy 2.7 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-lua5.4.4.yaml
+++ b/.github/workflows/library-lua5.4.4.yaml
@@ -83,3 +83,110 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/lua:5.4.4
         push: true
+
+  run-remote:
+    name: Test Lua 5.4.4 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup remote unikernel
+        run: |
+          set -euo pipefail
+
+          echo "Setup bridge network"
+          sudo kraft net create -n 172.44.0.1/24 virbr0 || true
+
+          echo "Pull and run unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/lua:5.4.4
+          kraft pkg pull "$IMAGE"
+          sudo kraft run --rm -M 512M --network bridge:virbr0 "$IMAGE" &
+          PID=$!
+          sleep 5
+
+          echo "Wait for port 8080"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z 172.44.0.2 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 on 172.44.0.2 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections on 172.44.0.2"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://172.44.0.2:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup unikernel"
+          sudo kill "$PID" || true
+
+  run-local:
+    name: Test Lua 5.4.4 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+
+      - name: Build, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/lua/5.4.4
+
+          echo "Build Lua 5.4.4 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run Lua 5.4.4 unikernel"
+          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "Wait for port 8080"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup Lua 5.4.4 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-lua5.4.yaml
+++ b/.github/workflows/library-lua5.4.yaml
@@ -85,3 +85,65 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/lua:5.4
         push: true
+
+  run-remote:
+    name: Test Lua 5.4 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Run and validate
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/lua:5.4
+
+          echo "Pull and run Lua 5.4"
+          OUTPUT=$(docker run --rm "$IMAGE")
+
+          echo "Validate output"
+          EXPECTED="Hello, World!"
+          if [ "$OUTPUT" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$OUTPUT'" >&2
+            exit 1
+          fi
+          echo "Lua 5.4 unikernel output is correct: '$OUTPUT'"
+
+  run-local:
+    name: Test Lua 5.4 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+
+      - name: Build, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/lua/5.4
+  
+          echo "Build Lua 5.4 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run Lua 5.4 unikernel and capture output"
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "Lua 5.4 unikernel started successfully locally"
+
+          echo "Cleanup Lua 5.4 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-node18.yaml
+++ b/.github/workflows/library-node18.yaml
@@ -83,3 +83,107 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/node:18
         push: true
+
+  run-remote:
+    name: Test Node 18 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+  
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup remote container
+        run: |
+          set -euo pipefail
+
+          echo "Pull and start unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/node:18
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
+
+          echo "Wait for port 8080"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+
+  run-local:
+    name: Test Node 18 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+
+      - name: Build, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/node/18
+
+          echo "Build Node 18 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run Node 18 unikernel"
+          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "Wait for port 8080"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, world!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup Node 18 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-node19.yaml
+++ b/.github/workflows/library-node19.yaml
@@ -1,0 +1,189 @@
+name: library/node:19
+
+on:
+  repository_dispatch:
+    types: [core_merge, elfloader_merge, libelf_merge, lwip_merge]
+
+  workflow_dispatch:
+
+  schedule:
+  - cron: '0 0 * * *' # Everyday at 12AM
+
+  push:
+    branches: [main]
+    paths:
+    - 'library/node/19/**'
+    - '.github/workflows/library-node19.yaml'
+    - '!library/node/19/README.md'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+    - 'library/node/19/**'
+    - '.github/workflows/library-node19.yaml'
+    - '!library/node/19/README.md'
+
+# Automatically cancel in-progress actions on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - plat: qemu
+          arch: x86_64
+        - plat: fc
+          arch: x86_64
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build node19
+      uses: unikraft/kraftkit@staging
+      with:
+        loglevel: debug
+        workdir: library/node/19
+        runtimedir: /github/workspace/.kraftkit
+        plat: ${{ matrix.plat }}
+        arch: ${{ matrix.arch }}
+        push: false
+        output: oci://index.unikraft.io/unikraft.org/node:19
+
+    - name: Archive OCI digests
+      uses: actions/upload-artifact@v4
+      with:
+        name: oci-digests-${{ matrix.arch }}-${{ matrix.plat }}
+        path: ${{ github.workspace }}/.kraftkit/oci/digests
+        if-no-files-found: error
+
+  push:
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Login to OCI registry
+      uses: docker/login-action@v3
+      with:
+        registry: index.unikraft.io
+        username: ${{ secrets.REG_USERNAME }}
+        password: ${{ secrets.REG_TOKEN }}
+
+    - name: Retrieve, merge and push OCI digests
+      uses: ./.github/actions/merge-oci-digests
+      with:
+        name: index.unikraft.io/unikraft.org/node:19
+        push: true
+
+  run-remote:
+    name: Test Node 19 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup remote container
+        run: |
+          set -euo pipefail
+
+          echo "Pull and start unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/node:19
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
+
+          echo "Wait for port 8080"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test Node 19 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+
+      - name: Build, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/node/19
+
+          echo "Build Node 19 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run Node 19 unikernel"
+          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "Wait for port 8080"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup Node 19 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-node20.yaml
+++ b/.github/workflows/library-node20.yaml
@@ -81,3 +81,107 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/node:20
         push: true
+
+  run-remote:
+    name: Test Node 20 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup remote container
+        run: |
+          set -euo pipefail
+
+          echo "Pull and start unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/node:20
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
+
+          echo "Wait for port 8080"
+          TIMEOUT=15
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test Node 20 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+
+      - name: Build, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/node/20
+
+          echo "Build Node 20 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run Node 20 unikernel"
+          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "Wait for port 8080"
+          TIMEOUT=15
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup Node 20 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-node21.yaml
+++ b/.github/workflows/library-node21.yaml
@@ -83,3 +83,107 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/node:21
         push: true
+
+  run-remote:
+    name: Test Node 21 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup container
+        run: |
+          set -euo pipefail
+
+          echo "Pull and start unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/node:21
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
+
+          echo "Wait for port 8080"
+          TIMEOUT=15
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+
+  run-local:
+    name: Test Node 21 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+
+      - name: Build, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/node/21
+
+          echo "Build Node 21 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run Node 21 unikernel"
+          kraft run --rm -M 512M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "Wait for port 8080"
+          TIMEOUT=15
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup Node 21 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-perl5.38.yaml
+++ b/.github/workflows/library-perl5.38.yaml
@@ -83,3 +83,107 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/perl:5.38
         push: true
+
+  run-remote:
+    name: Test Perl 5.38 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup remote container
+        run: |
+          set -euo pipefail
+
+          echo "Pull and start unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/perl:5.38
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 8080:8080 "$IMAGE")
+
+          echo "Wait for port 8080"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+
+  run-local:
+    name: Test Perl 5.38 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+
+      - name: Build, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/perl/5.38
+
+          echo "Build Perl 5.38 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run Perl 5.38 unikernel"
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "Wait for port 8080"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/ | tr -d '\r\n')
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup Perl 5.38 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-python3.10.yaml
+++ b/.github/workflows/library-python3.10.yaml
@@ -81,3 +81,70 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/python:3.10
         push: true
+
+  run-remote:
+    name: Test Python 3.10 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+
+          echo "Pull and start Python 3.10 unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/python:3.10
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: Python 3.10 unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "Python 3.10 unikernel started successfully"
+
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test Python 3.10 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+
+      - name: Build, run and validate unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/python/3.10
+
+          echo "Build Python 3.10 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run Python 3.10 unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "Python 3.10 unikernel started successfully locally"
+
+          echo "Cleanup Python 3.10 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-python3.12.yaml
+++ b/.github/workflows/library-python3.12.yaml
@@ -81,3 +81,90 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/python:3.12
         push: true
+
+  run-remote:
+    name: Test Python 3.12 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+
+          echo "Pull and start Python 3.12 unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/python:3.12
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: Python 3.12 unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "Python 3.12 unikernel started successfully"
+
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+
+  run-local:
+    name: Test Python 3.12 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+
+      - name: Build, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/python/3.12
+  
+          echo "Build Python 3.12 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run Python 3.12 unikernel"
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+  
+          echo "Wait for port 8080"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+  
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+  
+          echo "Cleanup Python 3.12 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-python3.13.yaml
+++ b/.github/workflows/library-python3.13.yaml
@@ -76,3 +76,92 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/python:3.13
         push: true
+
+  run-remote:
+    name: Test Python 3.13 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+
+          echo "Pull and start Python 3.13 unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/python:3.13
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: Python 3.13 unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "Python 3.13 unikernel started successfully"
+
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+
+  run-local:
+    name: Test Python 3.13 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+
+      - name: Build, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/python/3.13
+
+          echo "Build Python 3.13 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run Python 3.13 unikernel"
+          kraft run --rm -M 256M -p 8080:8080 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "Wait for port 8080"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 8080 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 8080 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:8080/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+
+          echo "Cleanup Python 3.13 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-redis7.2.yaml
+++ b/.github/workflows/library-redis7.2.yaml
@@ -81,3 +81,105 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/redis:7.2
         push: true
+
+  run-remote:
+    name: Test Redis 7.2 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, ping, and cleanup remote unikernel
+        run: |
+          set -euo pipefail
+
+          echo "Pull and start Redis unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/redis:7.2
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d -p 6379:6379 "$IMAGE")
+
+          echo "Install redis-cli"
+          sudo apt-get update -y && sudo apt-get install -y redis-tools
+
+          echo "Wait for port 6379"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 6379; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: Redis port 6379 did not open within ${TIMEOUT}s" >&2
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "Send PING to Redis"
+          if ! redis-cli -h 127.0.0.1 -p 6379 ping | grep -q "PONG"; then
+            echo "ERROR: Redis did not respond to PING" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "Redis 7.2 unikernel responded to PING with PONG"
+
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+  
+  run-local:
+    name: Test Redis 7.2 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI and redis-tools
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit redis-tools
+
+      - name: Build, run, ping, and cleanup unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/redis/7.2
+
+          echo "Build Redis 7.2 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run Redis 7.2 unikernel"
+          kraft run --rm -M 256M -p 6379:6379 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "Wait for port 6379"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 6379; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: Redis port 6379 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Redis is now accepting connections on port 6379"
+
+          echo "Validate Redis PING"
+          if ! redis-cli -h 127.0.0.1 -p 6379 ping | grep -q "PONG"; then
+            echo "ERROR: Redis did not respond to PING" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Redis 7.2 responded correctly to PING"
+
+          echo "Cleanup Redis 7.2 unikernel"
+          sudo kill "$PID" || true


### PR DESCRIPTION
### Summary

This PR adds full GitHub Actions test support (both `run-local` and `run-remote`) for the following Unikraft library packages:

- `bun:1.1`
- `caddy:2.7`
- `lua:5.4`, `lua:5.4.4`
- `node:18`, `node:19`, `node:20`, `node:21`
- `perl:5.38`
- `python:3.10`, `python:3.12`, `python:3.13`
- `redis:7.2`

Each workflow includes:
- ✅  `run-local`: Builds and runs the unikernel locally using QEMU
- ⚠️  `run-remote`: Pulls the OCI image and validates it via Docker, but **not yet tested** due to missing `REG_USERNAME` `REG_TOKEN` secrets

Test logic performs basic functional checks, such as:
- HTTP response matching `"Hello, World!"` or `"Hello, world!"`
- CLI validation using tools like `redis-cli ping`

This setup improves test coverage and ensures that:
- Unikernels build and run properly in local QEMU environments
- Future remote OCI image validation is ready once registry access is configured

### Note

:warning: Only `run-local` tests were executed during development. The `run-remote` jobs are included in this PR but were **not verified**, as I do not have access to the required OCI registry credentials (`REG_USERNAME`, `REG_TOKEN`) needed to authenticate against `index.unikraft.io`.

### Checklist

- [x] Read the contribution guidelines at https://unikraft.org/docs/contributing/unikraft  
- [x] Test `run-local` for all updated libraries  
- [ ] Validate `run-remote` OCI images with secrets  
- [ ] Run `checkpatch.pl` on commit series before opening the PR  
- [ ] Update relevant documentation (if applicable)  