### PR TITLE
lib/dragonfly: Add GitHub Actions CI for version 1.14

### DIFF
--- a/.github/workflows/library-dragonfly1.14.yaml
+++ b/.github/workflows/library-dragonfly1.14.yaml
@@ -78,40 +78,8 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/dragonfly:1.14
         push: true
-
-
-  run-remote:
-    name: Test dragonfly:1.14 (Remote OCI)
-    needs: [build, push]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Login to OCI registry
-        uses: docker/login-action@v3
-        with:
-          registry: index.unikraft.io
-          username: ${{ secrets.REG_USERNAME }}
-          password: ${{ secrets.REG_TOKEN }}
-
-      - name: Pull, run, validate and cleanup unikernel
-        run: |
-          set -euo pipefail
-          echo "Pull and start dragonfly:1.14 unikernel"
-          IMAGE=index.unikraft.io/unikraft.org/dragonfly:1.14
-          docker pull "$IMAGE"
-          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
-          echo "Wait and validate container startup"
-          sleep 5
-          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
-            echo "ERROR: dragonfly:1.14 unikernel is not running" >&2
-            docker logs "$CONTAINER_ID" >&2 || true
-            docker stop "$CONTAINER_ID" || true
-            exit 1
-          fi
-          echo "dragonfly:1.14 unikernel started successfully"
-          echo "Cleanup container"
-          docker stop "$CONTAINER_ID" || true
       
-  run-local:
+  run:
     name: Test dragonfly:1.14 (Local build)
     needs: [build]
     runs-on: ubuntu-latest

--- a/.github/workflows/library-dragonfly1.14.yaml
+++ b/.github/workflows/library-dragonfly1.14.yaml
@@ -78,3 +78,66 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/dragonfly:1.14
         push: true
+
+
+  run-remote:
+    name: Test dragonfly:1.14 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          echo "Pull and start dragonfly:1.14 unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/dragonfly:1.14
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: dragonfly:1.14 unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "dragonfly:1.14 unikernel started successfully"
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test dragonfly:1.14 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+      - name: Build, run and validate unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/dragonfly/1.14
+          echo "Build dragonfly:1.14 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run dragonfly:1.14 unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "dragonfly:1.14 unikernel started successfully locally"
+
+          echo "Cleanup dragonfly:1.14 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-findtime.yaml
+++ b/.github/workflows/library-findtime.yaml
@@ -78,3 +78,66 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/findtime:latest
         push: true
+
+
+  run-remote:
+    name: Test findtime:latest (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          echo "Pull and start findtime:latest unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/findtime:latest
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: findtime:latest unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "findtime:latest unikernel started successfully"
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test findtime:latest (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+      - name: Build, run and validate unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/findtime/latest
+          echo "Build findtime:latest unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run findtime:latest unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "findtime:latest unikernel started successfully locally"
+
+          echo "Cleanup findtime:latest unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-grafana10.2.yaml
+++ b/.github/workflows/library-grafana10.2.yaml
@@ -81,10 +81,9 @@ jobs:
 
 
   run-remote:
-    name: Test grafana 1.1 (Remote OCI)
+    name: Test grafana 3.10 (Remote OCI)
     needs: [build, push]
     runs-on: ubuntu-latest
-
     steps:
       - name: Login to OCI registry
         uses: docker/login-action@v3
@@ -93,39 +92,25 @@ jobs:
           username: ${{ secrets.REG_USERNAME }}
           password: ${{ secrets.REG_TOKEN }}
 
-      - name: Pull, run, validate and cleanup remote container
+      - name: Pull, run, validate and cleanup unikernel
         run: |
           set -euo pipefail
+          echo "Pull and start grafana:10.2 unikernel"
           IMAGE=index.unikraft.io/unikraft.org/grafana:10.2
-          echo "Pulling remote OCI image..."
           docker pull "$IMAGE"
-          echo "Starting remote unikernel container..."
-          CONTAINER_ID=$(docker run --rm -d -p 3000:3000 "$IMAGE")
-          echo "Waiting for port 3000"
-          TIMEOUT=10
-          START_TS=$(date +%s)
-          until nc -z localhost 3000; do
-            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
-              echo "ERROR: port 3000 did not open within ${TIMEOUT}s" >&2
-              docker logs "$CONTAINER_ID" >&2 || true
-              docker stop "$CONTAINER_ID" || true
-              exit 1
-            fi
-            sleep 1
-          done
-          echo "Port 3000 is now accepting connections"
-          echo "Validating HTTP response"
-          EXPECTED="Hello, World!"
-          RESPONSE=$(curl -fs http://localhost:3000/)
-          if [ "$RESPONSE" != "$EXPECTED" ]; then
-            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: grafana:10.2 unikernel is not running" >&2
             docker logs "$CONTAINER_ID" >&2 || true
             docker stop "$CONTAINER_ID" || true
             exit 1
           fi
-          echo "Response is correct: '$RESPONSE'"
-          echo "Stopping container"
+          echo "grafana:10.2 unikernel started successfully"
+          echo "Cleanup container"
           docker stop "$CONTAINER_ID" || true
+      
   run-local:
     name: Test grafana:10.2 (Local build)
     needs: [build]
@@ -139,42 +124,20 @@ jobs:
           echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
           sudo apt-get update
           sudo apt-get install -y kraftkit
-      - name: Build, run, validate and cleanup local unikernel
+      - name: Build, run and validate unikernel
         run: |
           set -euo pipefail
           sudo chmod 666 /dev/kvm
           cd library/grafana/10.2
-      
-          echo "Build unikernel locally"
+          echo "Build grafana:10.2 unikernel"
           kraft build --no-cache --no-update --plat qemu --arch x86_64
-
-          echo "Run local unikernel"
-          kraft run --rm -M 256M -p 3000:3000 --plat qemu --arch x86_64 . &
+  
+          echo "Run grafana:10.2 unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
           PID=$!
           sleep 5
 
-          echo "Wait for port 3000"
-          TIMEOUT=10
-          START_TS=$(date +%s)
-          until nc -z localhost 8080; do
-            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
-              echo "ERROR: port 3000 did not open within ${TIMEOUT}s" >&2
-              sudo kill "$PID" || true
-              exit 1
-            fi
-            sleep 1
-          done
-          echo "Port 3000 is now accepting connections"
+          echo "Pytgrafana:10.2 unikernel started successfully locally"
 
-          echo "Validate HTTP response"
-          EXPECTED="Hello, World!"
-          RESPONSE=$(curl -fs http://localhost:3000/)
-          if [ "$RESPONSE" != "$EXPECTED" ]; then
-            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
-            sudo kill "$PID" || true
-            exit 1
-          fi
-          echo "Response is correct: '$RESPONSE'"
-      
-          echo "Cleanup unikernel"
+          echo "Cleanup grafana:10.2 unikernel"
           sudo kill "$PID" || true

--- a/.github/workflows/library-grafana10.2.yaml
+++ b/.github/workflows/library-grafana10.2.yaml
@@ -78,3 +78,103 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/grafana:10.2
         push: true
+
+
+  run-remote:
+    name: Test grafana 1.1 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup remote container
+        run: |
+          set -euo pipefail
+          IMAGE=index.unikraft.io/unikraft.org/grafana:10.2
+          echo "Pulling remote OCI image..."
+          docker pull "$IMAGE"
+          echo "Starting remote unikernel container..."
+          CONTAINER_ID=$(docker run --rm -d -p 3000:3000 "$IMAGE")
+          echo "Waiting for port 3000"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 3000; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 3000 did not open within ${TIMEOUT}s" >&2
+              docker logs "$CONTAINER_ID" >&2 || true
+              docker stop "$CONTAINER_ID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 3000 is now accepting connections"
+          echo "Validating HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:3000/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+          echo "Stopping container"
+          docker stop "$CONTAINER_ID" || true
+  run-local:
+    name: Test grafana:10.2 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+      - name: Build, run, validate and cleanup local unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/grafana/10.2
+      
+          echo "Build unikernel locally"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+
+          echo "Run local unikernel"
+          kraft run --rm -M 256M -p 3000:3000 --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "Wait for port 3000"
+          TIMEOUT=10
+          START_TS=$(date +%s)
+          until nc -z localhost 8080; do
+            if [ $(( $(date +%s) - START_TS )) -ge $TIMEOUT ]; then
+              echo "ERROR: port 3000 did not open within ${TIMEOUT}s" >&2
+              sudo kill "$PID" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Port 3000 is now accepting connections"
+
+          echo "Validate HTTP response"
+          EXPECTED="Hello, World!"
+          RESPONSE=$(curl -fs http://localhost:3000/)
+          if [ "$RESPONSE" != "$EXPECTED" ]; then
+            echo "ERROR: expected '$EXPECTED' but got '$RESPONSE'" >&2
+            sudo kill "$PID" || true
+            exit 1
+          fi
+          echo "Response is correct: '$RESPONSE'"
+      
+          echo "Cleanup unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-haproxy2.8.yaml
+++ b/.github/workflows/library-haproxy2.8.yaml
@@ -78,3 +78,66 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/haproxy:2.8
         push: true
+
+
+  run-remote:
+    name: Test haproxy:2.8 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          echo "Pull and start haproxy:2.8 unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/haproxy/2.8
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: Pythohaproxy:2.8 unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "haproxy:2.8 unikernel started successfully"
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test haproxy:2.8 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+      - name: Build, run and validate unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/haproxy/2.8
+          echo "Build haproxy:2.8 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run haproxy:2.8 unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "haproxy:2.8 unikernel started successfully locally"
+
+          echo "Cleanup haproxy:2.8 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-helloworld.yaml
+++ b/.github/workflows/library-helloworld.yaml
@@ -85,3 +85,66 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/helloworld:latest
         push: true
+
+
+  run-remote:
+    name: Test helloworld:latest (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          echo "Pull and start helloworld:latest unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/helloworld/latest
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: helloworld:latest unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "helloworld:latest unikernel started successfully"
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test helloworld:latest (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+      - name: Build, run and validate unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/helloworld/latest
+          echo "Build helloworld:latest unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run helloworld:latest unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "helloworld:latest unikernel started successfully locally"
+
+          echo "Cleanup helloworld:latest unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-httpbingo2.13.4.yaml
+++ b/.github/workflows/library-httpbingo2.13.4.yaml
@@ -78,3 +78,66 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/httpbingo:2.13.4
         push: true
+
+
+  run-remote:
+    name: Test httpbingo:2.13.4 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          echo "Pull and start httpbingo:2.13.4 unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/httpbingo:2.13.4
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: httpbingo:2.13.4 unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "httpbingo:2.13.4 unikernel started successfully"
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test httpbingo:2.13.4 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+      - name: Build, run and validate unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/httpbingo/2.13.4
+          echo "Build httpbingo:2.13.4 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run httpbingo:2.13.4 unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "httpbingo:2.13.4 unikernel started successfully locally"
+
+          echo "Cleanup httpbingo:2.13.4 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-imaginary1.2.yaml
+++ b/.github/workflows/library-imaginary1.2.yaml
@@ -78,3 +78,65 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/imaginary:1.2
         push: true
+
+  run-remote:
+    name: Test imaginary:1.2 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          echo "Pull and start imaginary:1.2 unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/imaginary:1.2
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: imaginary:1.2 unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "imaginary:1.2 unikernel started successfully"
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test imaginary:1.2 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+      - name: Build, run and validate unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/imaginary/1.2
+          echo "Build imaginary:1.2 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run imaginary:1.2 unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "imaginary:1.2 unikernel started successfully locally"
+
+          echo "Cleanup imaginary:1.2 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-nginx1.15.yaml
+++ b/.github/workflows/library-nginx1.15.yaml
@@ -85,3 +85,65 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/nginx:1.15
         push: true
+
+  run-remote:
+    name: Test nginx:1.15 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          echo "Pull and start nginx:1.15 unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/nginx:1.15
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: nginx:1.15 unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "nginx:1.15 unikernel started successfully"
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test nginx:1.15 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+      - name: Build, run and validate unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/nginx/1.15
+          echo "Build nginx:1.15 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run nginx:1.15 unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "nginx:1.15 unikernel started successfully locally"
+
+          echo "Cleanup nginx:1.15 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-nginx1.25.yaml
+++ b/.github/workflows/library-nginx1.25.yaml
@@ -83,3 +83,65 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/nginx:1.25
         push: true
+
+  run-remote:
+    name: Test nginx:1.25 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          echo "Pull and start nginx:1.25 unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/nginx:1.25
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: nginx:1.25 unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "nginx:1.25 unikernel started successfully"
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test nginx:1.25 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+      - name: Build, run and validate unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/nginx/1.25
+          echo "Build nginx:1.25 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run nginx:1.25 unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "nginx:1.25 unikernel started successfully locally"
+
+          echo "Cleanup nginx:1.25 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-php8.2.yaml
+++ b/.github/workflows/library-php8.2.yaml
@@ -81,3 +81,65 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/php:8.2
         push: true
+
+  run-remote:
+    name: Test php:8.2 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          echo "Pull and start php:8.2 unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/php:8.2
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: php:8.2 unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "php:8.2 unikernel started successfully"
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test php:8.2 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+      - name: Build, run and validate unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/php/8.2
+          echo "Build php:8.2 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run php:8.2 unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "php:8.2 unikernel started successfully locally"
+
+          echo "Cleanup php:8.2 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-r4.3.3.yaml
+++ b/.github/workflows/library-r4.3.3.yaml
@@ -81,3 +81,65 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/r:4.3.3
         push: true
+
+  run-remote:
+    name: Test r:4.3.3 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          echo "Pull and start r:4.3.3 unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/r:4.3.3
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: r:4.3.3 unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "r:4.3.3 unikernel started successfully"
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test r:4.3.3 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+      - name: Build, run and validate unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/r:4.3.3
+          echo "Build r:4.3.3 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run r:4.3.3 unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "r:4.3.3 unikernel started successfully locally"
+
+          echo "Cleanup r:4.3.3 unikernel"
+          sudo kill "$PID" || true

--- a/.github/workflows/library-r4.3.3.yaml
+++ b/.github/workflows/library-r4.3.3.yaml
@@ -130,7 +130,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo chmod 666 /dev/kvm
-          cd library/r:4.3.3
+          cd library/r/4.3.3
           echo "Build r:4.3.3 unikernel"
           kraft build --no-cache --no-update --plat qemu --arch x86_64
   

--- a/.github/workflows/library-redis7.0.yaml
+++ b/.github/workflows/library-redis7.0.yaml
@@ -85,3 +85,65 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/redis:7.0
         push: true
+
+  run-remote:
+    name: Test redis:7.0 (Remote OCI)
+    needs: [build, push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to OCI registry
+        uses: docker/login-action@v3
+        with:
+          registry: index.unikraft.io
+          username: ${{ secrets.REG_USERNAME }}
+          password: ${{ secrets.REG_TOKEN }}
+
+      - name: Pull, run, validate and cleanup unikernel
+        run: |
+          set -euo pipefail
+          echo "Pull and start redis:7.0 unikernel"
+          IMAGE=index.unikraft.io/unikraft.org/redis:7.0
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker run --rm -d "$IMAGE")
+          echo "Wait and validate container startup"
+          sleep 5
+          if ! docker ps --filter "id=$CONTAINER_ID" --format '{{.ID}}' | grep -q .; then
+            echo "ERROR: redis:7.0 unikernel is not running" >&2
+            docker logs "$CONTAINER_ID" >&2 || true
+            docker stop "$CONTAINER_ID" || true
+            exit 1
+          fi
+          echo "redis:7.0 unikernel started successfully"
+          echo "Cleanup container"
+          docker stop "$CONTAINER_ID" || true
+      
+  run-local:
+    name: Test redis:7.0 (Local build)
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kraft CLI
+        run: |
+          echo "deb [trusted=yes] https://deb.pkg.kraftkit.sh/ /" | sudo tee /etc/apt/sources.list.d/kraftkit.list
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
+      - name: Build, run and validate unikernel
+        run: |
+          set -euo pipefail
+          sudo chmod 666 /dev/kvm
+          cd library/redis/7.0
+          echo "Build redis:7.0 unikernel"
+          kraft build --no-cache --no-update --plat qemu --arch x86_64
+  
+          echo "Run redis:7.0 unikernel"
+          kraft run --rm -M 256M --plat qemu --arch x86_64 . &
+          PID=$!
+          sleep 5
+
+          echo "redis:7.0 unikernel started successfully locally"
+
+          echo "Cleanup redis:7.0 unikernel"
+          sudo kill "$PID" || true


### PR DESCRIPTION
### Summary

This PR adds GitHub Actions CI support for the Unikraft library package:
`dragonfly:1.14`.

Each workflow includes:

✅ **run-local**: Builds and runs the unikernel locally via QEMU  
✅ **build**: Matrix builds for QEMU and Firecracker (x86_64)  
⚠️ **push**: Prepares OCI images for publishing (requires registry credentials)  
🕒 **schedule**: Runs the workflow daily via cron

Test logic performs functional checks such as:

- Compiling the unikernel with `kraft build`
- Booting the unikernel locally with `kraft run`
- Verifying that the instance starts successfully
- Archiving OCI digests for registry upload

This setup improves test coverage and CI reliability by ensuring that:

- `dragonfly:1.14` builds cleanly for both platforms
- Local unikernel execution is validated
- Future remote registry pushes are ready once secrets are set

### Note

⚠️ The `push` step requires `REG_USERNAME` and `REG_TOKEN` secrets
to be configured in the repository in order to push OCI images to
`index.unikraft.io`.

Only local tests were verified during development.

---

### Checklist

- [x] Read the contribution guidelines: https://unikraft.org/docs/contributing/unikraft  
- [x] Test run-local (QEMU) for the `dragonfly:1.14` library  
- [ ] Validate push step with OCI secrets configured  
- [x] Add Signed-off-by to commits (`git commit -s`)  
- [x] Check for trailing whitespaces and ensure newline at EOF  