### PR TITLE
feat(library): Add hyde theme for Hugo

### DIFF
--- a/library/hugo/0.122/Dockerfile
+++ b/library/hugo/0.122/Dockerfile
@@ -16,8 +16,8 @@ WORKDIR /site
 
 RUN set -xe; \
     hugo new site .; \
-    git clone --depth 1 https://github.com/budparr/gohugo-theme-ananke.git themes/ananke; \
-    echo 'theme = "ananke"' >> hugo.toml \
+    git clone --depth 1 https://github.com/spf13/hyde themes/hyde; \
+    echo 'theme = "hyde"' >> hugo.toml \
     ;
 
 FROM alpine:3 AS sys


### PR DESCRIPTION
Use `hyde` theme for Hugo. The `ananke` theme is not compatible with the currently used version of Hugo.