### PR TITLE
fix(examples): Use cmd argument in Kraftfile helloworld-zig

### DIFF
--- a/examples/helloworld-zig0.11/Kraftfile
+++ b/examples/helloworld-zig0.11/Kraftfile
@@ -6,4 +6,4 @@ runtime: unikraft.org/base:latest
 
 rootfs: ./Dockerfile
 
-args: ["/helloworld"]
+cmd: ["/helloworld"]


### PR DESCRIPTION
By mistake, the `args` keyword is used instead of `cmd` in the `Kraftfile` for `helloworld-zig`. Fix that.