### PR TITLE
fix(examples): Install openssl from correct Node Alpine version

### DIFF
--- a/examples/prisma-expressjs4.18-node21-base/Dockerfile
+++ b/examples/prisma-expressjs4.18-node21-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21-alpine AS base
+FROM node:21-alpine3.20 AS base
 
 WORKDIR /app
 
@@ -8,6 +8,7 @@ RUN npm install
 
 FROM alpine:3 AS sys
 
+RUN apk add --no-cache openssl
 RUN set -xe; \
     mkdir -p /target/etc; \
     mkdir -p /blank; \

--- a/examples/prisma-expressjs4.18-node21/Dockerfile
+++ b/examples/prisma-expressjs4.18-node21/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21-alpine AS deps
+FROM node:21-alpine3.20 AS deps
 
 WORKDIR /app
 
@@ -13,6 +13,8 @@ WORKDIR /app
 COPY ./webpack.config.js /app/
 COPY ./src /app/src
 COPY ./prisma /app/prisma
+
+RUN apk add --no-cache openssl
 
 RUN set -xe; \
     npx prisma generate; \

--- a/examples/prisma-expressjs4.19-node18/Dockerfile
+++ b/examples/prisma-expressjs4.19-node18/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS deps
+FROM node:18-alpine3.20 AS deps
 
 WORKDIR /app
 
@@ -13,6 +13,8 @@ WORKDIR /app
 COPY ./webpack.config.js /app/
 COPY ./src /app/src
 COPY ./prisma /app/prisma
+
+RUN apk add --no-cache openssl
 
 RUN set -xe; \
     npx prisma generate; \


### PR DESCRIPTION
The Node Prisma builds require OpenSSL. The location of the OpenSSL libraries depends on the Node Alpine build. So do two things:

- Specify exact version of Node Alpine build: `alpine3.20`
- Install OpenSSL via `apk add --no-cache openssl`