### PR TITLE
fix(examples): Remove unikraft.org from runtime paths

### DIFF
--- a/examples/flask3.0-python3.12/Kraftfile
+++ b/examples/flask3.0-python3.12/Kraftfile
@@ -2,7 +2,7 @@ spec: v0.6
 
 name: flask3.0-python3.12
 
-runtime: unikraft.org/python:3.12
+runtime: python:3.12
 
 rootfs: ./Dockerfile
 

--- a/examples/helloworld-zig0.11/Kraftfile
+++ b/examples/helloworld-zig0.11/Kraftfile
@@ -2,7 +2,7 @@ spec: v0.6
 
 name: helloworld-zig0.11
 
-runtime: unikraft.org/base:latest
+runtime: base:latest
 
 rootfs: ./Dockerfile
 


### PR DESCRIPTION
Certain runtimes feature `unikraft.org/<runtime_name>` in the `Kraftfile`. As `unikraft.org` is default, remove it.