### PR TITLE
Add Node22 and Node24 Express examples

### DIFF
--- a/examples/expressjs4.18-node22-base/.dockerignore
+++ b/examples/expressjs4.18-node22-base/.dockerignore
@@ -1,0 +1,6 @@
+dist/
+node_modules/
+/.unikraft/
+/Dockerfile
+/Kraftfile
+/README.md

--- a/examples/expressjs4.18-node22-base/.gitignore
+++ b/examples/expressjs4.18-node22-base/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/.unikraft/

--- a/examples/expressjs4.18-node22-base/Dockerfile
+++ b/examples/expressjs4.18-node22-base/Dockerfile
@@ -1,0 +1,43 @@
+FROM node:22-alpine AS node
+
+WORKDIR /usr/src
+
+COPY . /usr/src/
+
+RUN npm install
+
+
+FROM alpine:3 AS sys
+
+RUN set -xe; \
+    mkdir -p /target/etc; \
+    mkdir -p /blank; \
+    apk --no-cache add \
+    ca-certificates \
+    tzdata \
+    ; \
+    update-ca-certificates; \
+    ln -sf ../usr/share/zoneinfo/Etc/UTC /target/etc/localtime; \
+    echo "Etc/UTC" > /target/etc/timezone;
+
+FROM scratch
+
+COPY --from=sys /target/etc /etc
+COPY --from=sys /usr/share/zoneinfo/Etc/UTC /usr/share/zoneinfo/Etc/UTC
+COPY --from=sys /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=sys /blank /tmp
+
+# Node binary
+COPY --from=node /usr/local/bin/node /usr/bin/node
+
+# System libraries
+COPY --from=node /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=node /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=node /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+
+# Distribution configuration
+COPY --from=node /etc/os-release /etc/os-release
+
+# Express.js
+COPY --from=node /usr/src/node_modules /usr/src/node_modules
+COPY --from=node /usr/src/app/index.js /usr/src/server.js

--- a/examples/expressjs4.18-node22-base/Kraftfile
+++ b/examples/expressjs4.18-node22-base/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: expressjs4.18-node22-base
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/expressjs4.18-node22-base/README.md
+++ b/examples/expressjs4.18-node22-base/README.md
@@ -1,0 +1,64 @@
+# Node22 ExpressJS
+
+This directory contains a Node22 [`ExpressJS`](https://expressjs.com/) implementation running on Unikraft.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 3000:3000 --plat qemu --arch x86_64 -M 512M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `3000` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME                     KERNEL                      ARGS                              CREATED         STATUS   MEM   PORTS                   PLAT
+agitated_davidgreybeard  oci://unikraft.org/node:21  /usr/bin/node /usr/src/server.js  10 seconds ago  running  488M  0.0.0.0:3000->3000/tcp  qemu/x86_64
+```
+
+The instance name is `agitated_davidgreybeard`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm agitated_davidgreybeard
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run -p 3000:3000 --plat qemu --arch x86_64 -M 1024M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/expressjs4.18-node22-base/app/index.js
+++ b/examples/expressjs4.18-node22-base/app/index.js
@@ -1,0 +1,11 @@
+const express = require('express')
+const app = express()
+const port = 3000
+
+app.get('/', (req, res) => {
+  res.send('Bye, World!\n')
+})
+
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}`)
+})

--- a/examples/expressjs4.18-node22-base/package.json
+++ b/examples/expressjs4.18-node22-base/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/examples/expressjs4.18-node24-base/.dockerignore
+++ b/examples/expressjs4.18-node24-base/.dockerignore
@@ -1,0 +1,6 @@
+dist/
+node_modules/
+/.unikraft/
+/Dockerfile
+/Kraftfile
+/README.md

--- a/examples/expressjs4.18-node24-base/.gitignore
+++ b/examples/expressjs4.18-node24-base/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/.unikraft/

--- a/examples/expressjs4.18-node24-base/Dockerfile
+++ b/examples/expressjs4.18-node24-base/Dockerfile
@@ -1,0 +1,43 @@
+FROM node:24-alpine AS node
+
+WORKDIR /usr/src
+
+COPY . /usr/src/
+
+RUN npm install
+
+
+FROM alpine:3 AS sys
+
+RUN set -xe; \
+    mkdir -p /target/etc; \
+    mkdir -p /blank; \
+    apk --no-cache add \
+    ca-certificates \
+    tzdata \
+    ; \
+    update-ca-certificates; \
+    ln -sf ../usr/share/zoneinfo/Etc/UTC /target/etc/localtime; \
+    echo "Etc/UTC" > /target/etc/timezone;
+
+FROM scratch
+
+COPY --from=sys /target/etc /etc
+COPY --from=sys /usr/share/zoneinfo/Etc/UTC /usr/share/zoneinfo/Etc/UTC
+COPY --from=sys /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=sys /blank /tmp
+
+# Node binary
+COPY --from=node /usr/local/bin/node /usr/bin/node
+
+# System libraries
+COPY --from=node /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=node /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=node /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+
+# Distribution configuration
+COPY --from=node /etc/os-release /etc/os-release
+
+# Express.js
+COPY --from=node /usr/src/node_modules /usr/src/node_modules
+COPY --from=node /usr/src/app/index.js /usr/src/server.js

--- a/examples/expressjs4.18-node24-base/Kraftfile
+++ b/examples/expressjs4.18-node24-base/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: expressjs4.18-node24-base
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/expressjs4.18-node24-base/README.md
+++ b/examples/expressjs4.18-node24-base/README.md
@@ -1,0 +1,64 @@
+# Node24 ExpressJS
+
+This directory contains a Node24 [`ExpressJS`](https://expressjs.com/) implementation running on Unikraft.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 3000:3000 --plat qemu --arch x86_64 -M 512M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `3000` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME                     KERNEL                      ARGS                              CREATED         STATUS   MEM   PORTS                   PLAT
+agitated_davidgreybeard  oci://unikraft.org/node:21  /usr/bin/node /usr/src/server.js  10 seconds ago  running  488M  0.0.0.0:3000->3000/tcp  qemu/x86_64
+```
+
+The instance name is `agitated_davidgreybeard`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm agitated_davidgreybeard
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run -p 3000:3000 --plat qemu --arch x86_64 -M 1024M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/expressjs4.18-node24-base/app/index.js
+++ b/examples/expressjs4.18-node24-base/app/index.js
@@ -1,0 +1,11 @@
+const express = require('express')
+const app = express()
+const port = 3000
+
+app.get('/', (req, res) => {
+  res.send('Bye, World!\n')
+})
+
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}`)
+})

--- a/examples/expressjs4.18-node24-base/package.json
+++ b/examples/expressjs4.18-node24-base/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
This PR adds Node22 and Node24 Express examples that uses the base runtime:

- expressjs4.18-node22-base
- expressjs4.18-node24-base