### PR TITLE
Added Node22 and Node24 WebSocket server base-based examples

### DIFF
--- a/examples/websocket-node22-base/.dockerignore
+++ b/examples/websocket-node22-base/.dockerignore
@@ -1,0 +1,6 @@
+dist/
+node_modules/
+/.unikraft/
+/Dockerfile
+/Kraftfile
+/README.md

--- a/examples/websocket-node22-base/.gitignore
+++ b/examples/websocket-node22-base/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/.unikraft/

--- a/examples/websocket-node22-base/Dockerfile
+++ b/examples/websocket-node22-base/Dockerfile
@@ -1,0 +1,39 @@
+FROM node:22-alpine AS node
+
+WORKDIR /usr/src
+COPY package.json .
+COPY package-lock.json .
+RUN npm install
+
+FROM alpine:3 AS sys
+
+RUN set -xe; \
+    mkdir -p /target/etc; \
+    mkdir -p /blank; \
+    apk --no-cache add \
+    ca-certificates \
+    tzdata \
+    ; \
+    update-ca-certificates; \
+    ln -sf ../usr/share/zoneinfo/Etc/UTC /target/etc/localtime; \
+    echo "Etc/UTC" > /target/etc/timezone;
+
+FROM scratch
+
+COPY --from=sys /target/etc /etc
+COPY --from=sys /usr/share/zoneinfo/Etc/UTC /usr/share/zoneinfo/Etc/UTC
+COPY --from=sys /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=sys /blank /tmp
+
+# Node binary
+COPY --from=node /usr/local/bin/node /usr/bin/node
+
+# System libraries
+COPY --from=node /etc/ssl/openssl.cnf /etc/ssl/openssl.cnf
+COPY --from=node /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=node /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=node /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+
+# Node HTTP server
+COPY --from=node /usr/src /usr/src
+COPY ./src /usr/src

--- a/examples/websocket-node22-base/Kraftfile
+++ b/examples/websocket-node22-base/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: websocket-node22-base
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/websocket-node22-base/README.md
+++ b/examples/websocket-node22-base/README.md
@@ -1,0 +1,82 @@
+# Node22 WebSocket Server
+
+This directory contains a Node22 WebSocket echo server implementation running on Unikraft.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository, and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance locally:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 1024M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.  
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once running, it will open port `8080` and listen for WebSocket connections.
+
+To test it, you can use a WebSocket client like [`wscat`](https://github.com/websockets/wscat).
+
+Install `wscat` globally with `npm`:
+
+```bash
+npm install -g wscat
+```
+
+Then connect to the WebSocket server:
+
+```bash
+wscat --connect ws://localhost:8080
+```
+
+After connecting, you can enter messages, and the server will echo them back.
+
+```bash
+Connected (press CTRL+C to quit)
+< Connection received. Waiting for messages.
+> Hello
+< Hello
+> From
+< From
+> Unikraft
+< Unikraft 
+```
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+To stop the Unikraft instance, use `Ctrl+C` or:
+
+```bash
+kraft rm <INSTANCE_NAME>
+```
+
+## Note on Memory
+
+Depending on the size of your application, you may need to allocate more memory. You can do this by adjusting the `-M` flag:
+
+```bash
+kraft run -p 8080:8080 --plat qemu --arch x86_64 -M 1024M .
+```
+
+## `kraft` and `sudo`
+
+Mixing `kraft` with `sudo` can lead to unexpected behavior. Learn how to avoid using `sudo` with `kraft`:
+
+[https://unikraft.org/sudoless](https://unikraft.org/sudoless)
+
+## Learn More
+
+- [WebSocket (Wikipedia)](https://en.wikipedia.org/wiki/WebSocket)
+- [`ws` – A Node.js WebSocket library](https://github.com/websockets/ws)
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with BuildKit](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/websocket-node22-base/package-lock.json
+++ b/examples/websocket-node22-base/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "websocket",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "websocket",
+      "version": "0.1.0",
+      "dependencies": {
+        "ws": "^8.18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/examples/websocket-node22-base/package.json
+++ b/examples/websocket-node22-base/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "websocket",
+  "type": "module",
+  "version": "0.1.0",
+  "dependencies": {
+    "ws": "^8.18"
+  }
+}

--- a/examples/websocket-node22-base/src/server.js
+++ b/examples/websocket-node22-base/src/server.js
@@ -1,0 +1,24 @@
+import { WebSocketServer } from 'ws';
+
+const port = 8080;
+const wss = new WebSocketServer({ port: port });
+
+wss.on('connection', function connection(ws, req) {
+    const ip = req.socket.remoteAddress;
+
+    console.log('Client connected from %s', ip);
+    ws.send('Connection received. Waiting for messages.');
+
+    ws.on('error', console.error);
+
+    ws.on('message', function message(data) {
+        console.log('received: %s', data);
+        ws.send(data);
+    });
+
+    ws.on('close', function close() {
+        console.log('Client disconnected from %s', ip);
+    });
+});
+
+console.log('WebSocket server is running on ws://localhost:%d', port);

--- a/examples/websocket-node24-base/.dockerignore
+++ b/examples/websocket-node24-base/.dockerignore
@@ -1,0 +1,6 @@
+dist/
+node_modules/
+/.unikraft/
+/Dockerfile
+/Kraftfile
+/README.md

--- a/examples/websocket-node24-base/.gitignore
+++ b/examples/websocket-node24-base/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/.unikraft/

--- a/examples/websocket-node24-base/Dockerfile
+++ b/examples/websocket-node24-base/Dockerfile
@@ -1,0 +1,39 @@
+FROM node:24-alpine AS node
+
+WORKDIR /usr/src
+COPY package.json .
+COPY package-lock.json .
+RUN npm install
+
+FROM alpine:3 AS sys
+
+RUN set -xe; \
+    mkdir -p /target/etc; \
+    mkdir -p /blank; \
+    apk --no-cache add \
+    ca-certificates \
+    tzdata \
+    ; \
+    update-ca-certificates; \
+    ln -sf ../usr/share/zoneinfo/Etc/UTC /target/etc/localtime; \
+    echo "Etc/UTC" > /target/etc/timezone;
+
+FROM scratch
+
+COPY --from=sys /target/etc /etc
+COPY --from=sys /usr/share/zoneinfo/Etc/UTC /usr/share/zoneinfo/Etc/UTC
+COPY --from=sys /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=sys /blank /tmp
+
+# Node binary
+COPY --from=node /usr/local/bin/node /usr/bin/node
+
+# System libraries
+COPY --from=node /etc/ssl/openssl.cnf /etc/ssl/openssl.cnf
+COPY --from=node /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=node /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=node /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+
+# Node HTTP server
+COPY --from=node /usr/src /usr/src
+COPY ./src /usr/src

--- a/examples/websocket-node24-base/Kraftfile
+++ b/examples/websocket-node24-base/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: websocket-node24-base
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/websocket-node24-base/README.md
+++ b/examples/websocket-node24-base/README.md
@@ -1,0 +1,82 @@
+# Node24 WebSocket Server
+
+This directory contains a Node24 WebSocket echo server implementation running on Unikraft.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository, and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance locally:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 1024M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.  
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once running, it will open port `8080` and listen for WebSocket connections.
+
+To test it, you can use a WebSocket client like [`wscat`](https://github.com/websockets/wscat).
+
+Install `wscat` globally with `npm`:
+
+```bash
+npm install -g wscat
+```
+
+Then connect to the WebSocket server:
+
+```bash
+wscat --connect ws://localhost:8080
+```
+
+After connecting, you can enter messages, and the server will echo them back.
+
+```bash
+Connected (press CTRL+C to quit)
+< Connection received. Waiting for messages.
+> Hello
+< Hello
+> From
+< From
+> Unikraft
+< Unikraft 
+```
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+To stop the Unikraft instance, use `Ctrl+C` or:
+
+```bash
+kraft rm <INSTANCE_NAME>
+```
+
+## Note on Memory
+
+Depending on the size of your application, you may need to allocate more memory. You can do this by adjusting the `-M` flag:
+
+```bash
+kraft run -p 8080:8080 --plat qemu --arch x86_64 -M 1024M .
+```
+
+## `kraft` and `sudo`
+
+Mixing `kraft` with `sudo` can lead to unexpected behavior. Learn how to avoid using `sudo` with `kraft`:
+
+[https://unikraft.org/sudoless](https://unikraft.org/sudoless)
+
+## Learn More
+
+- [WebSocket (Wikipedia)](https://en.wikipedia.org/wiki/WebSocket)
+- [`ws` – A Node.js WebSocket library](https://github.com/websockets/ws)
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with BuildKit](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/websocket-node24-base/package-lock.json
+++ b/examples/websocket-node24-base/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "websocket",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "websocket",
+      "version": "0.1.0",
+      "dependencies": {
+        "ws": "^8.18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/examples/websocket-node24-base/package.json
+++ b/examples/websocket-node24-base/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "websocket",
+  "type": "module",
+  "version": "0.1.0",
+  "dependencies": {
+    "ws": "^8.18"
+  }
+}

--- a/examples/websocket-node24-base/src/server.js
+++ b/examples/websocket-node24-base/src/server.js
@@ -1,0 +1,24 @@
+import { WebSocketServer } from 'ws';
+
+const port = 8080;
+const wss = new WebSocketServer({ port: port });
+
+wss.on('connection', function connection(ws, req) {
+    const ip = req.socket.remoteAddress;
+
+    console.log('Client connected from %s', ip);
+    ws.send('Connection received. Waiting for messages.');
+
+    ws.on('error', console.error);
+
+    ws.on('message', function message(data) {
+        console.log('received: %s', data);
+        ws.send(data);
+    });
+
+    ws.on('close', function close() {
+        console.log('Client disconnected from %s', ip);
+    });
+});
+
+console.log('WebSocket server is running on ws://localhost:%d', port);


### PR DESCRIPTION
Introduce the WebSocket echo server examples that runs on Node22 and Node24 with QEMU on Unikraft. It improves transparency by exposing the runtime setup and usage of the ws client for validation.

Added:

- websocket-node22-base
- websocket-node24-base