### PR TITLE
fix(library): Fix Dockerfile for PHP 8.2

### DIFF
--- a/library/php/8.2/Dockerfile
+++ b/library/php/8.2/Dockerfile
@@ -30,49 +30,50 @@ COPY --from=build /usr/local/lib/libphp.so /usr/local/lib/libphp.so
 COPY --from=build /usr/local/lib/php /usr/local/lib/php
 
 # System libraries
-COPY --from=build /lib/x86_64-linux-gnu/libreadline.so.8 /lib/x86_64-linux-gnu/libreadline.so.8
-COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
-COPY --from=build /lib/x86_64-linux-gnu/libxml2.so.2 /lib/x86_64-linux-gnu/libxml2.so.2
-COPY --from=build /lib/x86_64-linux-gnu/libssl.so.3 /lib/x86_64-linux-gnu/libssl.so.3
-COPY --from=build /lib/x86_64-linux-gnu/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
-COPY --from=build /lib/x86_64-linux-gnu/libsqlite3.so.0 /lib/x86_64-linux-gnu/libsqlite3.so.0
-COPY --from=build /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
-COPY --from=build /lib/x86_64-linux-gnu/libcurl.so.4 /lib/x86_64-linux-gnu/libcurl.so.4
-COPY --from=build /lib/x86_64-linux-gnu/libonig.so.5 /lib/x86_64-linux-gnu/libonig.so.5
-COPY --from=build /lib/x86_64-linux-gnu/libargon2.so.1 /lib/x86_64-linux-gnu/libargon2.so.1
-COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
-COPY --from=build /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libtinfo.so.6
-COPY --from=build /lib/x86_64-linux-gnu/libicuuc.so.72 /lib/x86_64-linux-gnu/libicuuc.so.72
-COPY --from=build /lib/x86_64-linux-gnu/liblzma.so.5 /lib/x86_64-linux-gnu/liblzma.so.5
-COPY --from=build /lib/x86_64-linux-gnu/libnghttp2.so.14 /lib/x86_64-linux-gnu/libnghttp2.so.14
-COPY --from=build /lib/x86_64-linux-gnu/libidn2.so.0 /lib/x86_64-linux-gnu/libidn2.so.0
-COPY --from=build /lib/x86_64-linux-gnu/librtmp.so.1 /lib/x86_64-linux-gnu/librtmp.so.1
-COPY --from=build /lib/x86_64-linux-gnu/libssh2.so.1 /lib/x86_64-linux-gnu/libssh2.so.1
-COPY --from=build /lib/x86_64-linux-gnu/libpsl.so.5 /lib/x86_64-linux-gnu/libpsl.so.5
-COPY --from=build /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 /lib/x86_64-linux-gnu/libgssapi_krb5.so.2
-COPY --from=build /lib/x86_64-linux-gnu/libldap-2.5.so.0 /lib/x86_64-linux-gnu/libldap-2.5.so.0
-COPY --from=build /lib/x86_64-linux-gnu/liblber-2.5.so.0 /lib/x86_64-linux-gnu/liblber-2.5.so.0
-COPY --from=build /lib/x86_64-linux-gnu/libzstd.so.1 /lib/x86_64-linux-gnu/libzstd.so.1
-COPY --from=build /lib/x86_64-linux-gnu/libbrotlidec.so.1 /lib/x86_64-linux-gnu/libbrotlidec.so.1
-COPY --from=build /lib/x86_64-linux-gnu/libicudata.so.72 /lib/x86_64-linux-gnu/libicudata.so.72
-COPY --from=build /lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libstdc++.so.6
-COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
-COPY --from=build /lib/x86_64-linux-gnu/libunistring.so.2 /lib/x86_64-linux-gnu/libunistring.so.2
-COPY --from=build /lib/x86_64-linux-gnu/libgnutls.so.30 /lib/x86_64-linux-gnu/libgnutls.so.30
-COPY --from=build /lib/x86_64-linux-gnu/libhogweed.so.6 /lib/x86_64-linux-gnu/libhogweed.so.6
-COPY --from=build /lib/x86_64-linux-gnu/libnettle.so.8 /lib/x86_64-linux-gnu/libnettle.so.8
-COPY --from=build /lib/x86_64-linux-gnu/libgmp.so.10 /lib/x86_64-linux-gnu/libgmp.so.10
-COPY --from=build /lib/x86_64-linux-gnu/libkrb5.so.3 /lib/x86_64-linux-gnu/libkrb5.so.3
-COPY --from=build /lib/x86_64-linux-gnu/libk5crypto.so.3 /lib/x86_64-linux-gnu/libk5crypto.so.3
-COPY --from=build /lib/x86_64-linux-gnu/libcom_err.so.2 /lib/x86_64-linux-gnu/libcom_err.so.2
-COPY --from=build /lib/x86_64-linux-gnu/libkrb5support.so.0 /lib/x86_64-linux-gnu/libkrb5support.so.0
-COPY --from=build /lib/x86_64-linux-gnu/libsasl2.so.2 /lib/x86_64-linux-gnu/libsasl2.so.2
-COPY --from=build /lib/x86_64-linux-gnu/libbrotlicommon.so.1 /lib/x86_64-linux-gnu/libbrotlicommon.so.1
-COPY --from=build /lib/x86_64-linux-gnu/libp11-kit.so.0 /lib/x86_64-linux-gnu/libp11-kit.so.0
-COPY --from=build /lib/x86_64-linux-gnu/libtasn1.so.6 /lib/x86_64-linux-gnu/libtasn1.so.6
-COPY --from=build /lib/x86_64-linux-gnu/libkeyutils.so.1 /lib/x86_64-linux-gnu/libkeyutils.so.1
-COPY --from=build /lib/x86_64-linux-gnu/libresolv.so.2 /lib/x86_64-linux-gnu/libresolv.so.2
-COPY --from=build /lib/x86_64-linux-gnu/libffi.so.8 /lib/x86_64-linux-gnu/libffi.so.8
+COPY --from=build \
+                  /lib/x86_64-linux-gnu/libargon2.so.1 \
+                  /lib/x86_64-linux-gnu/libbrotlicommon.so.1 \
+                  /lib/x86_64-linux-gnu/libbrotlidec.so.1 \
+                  /lib/x86_64-linux-gnu/libcom_err.so.2 \
+                  /lib/x86_64-linux-gnu/libcrypto.so.3 \
+                  /lib/x86_64-linux-gnu/libc.so.6 \
+                  /lib/x86_64-linux-gnu/libcurl.so.4 \
+                  /lib/x86_64-linux-gnu/libffi.so.8 \
+                  /lib/x86_64-linux-gnu/libgmp.so.10 \
+                  /lib/x86_64-linux-gnu/libgnutls.so.30 \
+                  /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 \
+                  /lib/x86_64-linux-gnu/libhogweed.so.6 \
+                  /lib/x86_64-linux-gnu/libidn2.so.0 \
+                  /lib/x86_64-linux-gnu/libk5crypto.so.3 \
+                  /lib/x86_64-linux-gnu/libkeyutils.so.1 \
+                  /lib/x86_64-linux-gnu/libkrb5.so.3 \
+                  /lib/x86_64-linux-gnu/libkrb5support.so.0 \
+                  /lib/x86_64-linux-gnu/liblber.so.2 \
+                  /lib/x86_64-linux-gnu/libldap.so.2 \
+                  /lib/x86_64-linux-gnu/liblzma.so.5 \
+                  /lib/x86_64-linux-gnu/libm.so.6 \
+                  /lib/x86_64-linux-gnu/libnettle.so.8 \
+                  /lib/x86_64-linux-gnu/libnghttp2.so.14 \
+                  /lib/x86_64-linux-gnu/libnghttp3.so.9 \
+                  /lib/x86_64-linux-gnu/libonig.so.5 \
+                  /lib/x86_64-linux-gnu/libp11-kit.so.0 \
+                  /lib/x86_64-linux-gnu/libpsl.so.5 \
+                  /lib/x86_64-linux-gnu/libreadline.so.8 \
+                  /lib/x86_64-linux-gnu/libresolv.so.2 \
+                  /lib/x86_64-linux-gnu/librtmp.so.1 \
+                  /lib/x86_64-linux-gnu/libsasl2.so.2 \
+                  /lib/x86_64-linux-gnu/libsqlite3.so.0 \
+                  /lib/x86_64-linux-gnu/libssh2.so.1 \
+                  /lib/x86_64-linux-gnu/libssl.so.3 \
+                  /lib/x86_64-linux-gnu/libtasn1.so.6 \
+                  /lib/x86_64-linux-gnu/libtinfo.so.6 \
+                  /lib/x86_64-linux-gnu/libunistring.so.5 \
+                  /lib/x86_64-linux-gnu/libxml2.so.2 \
+                  /lib/x86_64-linux-gnu/libz.so.1 \
+                  /lib/x86_64-linux-gnu/libzstd.so.1 \
+                  /lib/x86_64-linux-gnu/
+
+# Dynamic linker/loader
 COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 
 # PHP configuration


### PR DESCRIPTION
Use correct library names in Dockerfile. The previous versions of the library were missing. Not sure if it was caused by an upstream update of the `php8.2-cli` Docker image, or they were faulty from the start.
    
Also use a single stage to copy all libraries in `/lib/x86_64-linux-gnu` and sort library files alphabetically.