### PR TITLE
fix(examples): Fix and update Python Dockerfiles

### DIFF
--- a/examples/flask3.0-python3.10-base/Dockerfile
+++ b/examples/flask3.0-python3.10-base/Dockerfile
@@ -1,26 +1,35 @@
-FROM python:3.10.11 AS base
+FROM python:3.10.18-bookworm AS base
 
 WORKDIR /app
 
 COPY requirements.txt /app
-
 RUN pip3 install -r requirements.txt --no-cache-dir
 
-FROM scratch
+RUN /usr/sbin/ldconfig /usr/local/lib
 
-# System libraries
-COPY --from=base /usr/local/lib/python3.10 /usr/local/lib/python3.10
-COPY --from=base /usr/local/bin/../lib/libpython3.10.so.1.0 /usr/local/bin/../lib/libpython3.10.so.1.0
-COPY --from=base /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
-COPY --from=base /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
-COPY --from=base /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
-COPY --from=base /lib/x86_64-linux-gnu/libutil.so.1 /lib/x86_64-linux-gnu/libutil.so.1
-COPY --from=base /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
-COPY --from=base /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
-COPY --from=base /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+FROM scratch
 
 # Python executable
 COPY --from=base /usr/local/bin/python3 /usr/local/bin/python3
 
-# Python files
+# System libraries
+COPY --from=base \
+                 /lib/x86_64-linux-gnu/libc.so.6 \
+                 /lib/x86_64-linux-gnu/libdl.so.2 \
+                 /lib/x86_64-linux-gnu/libm.so.6 \
+                 /lib/x86_64-linux-gnu/libpthread.so.0 \
+                 /lib/x86_64-linux-gnu/libutil.so.1 \
+                 /lib/x86_64-linux-gnu/libz.so.1 \
+                 /lib/x86_64-linux-gnu/
+
+# Python libraries
+COPY --from=base /usr/local/lib /usr/local/lib
+
+# Dynamic linker / loader
+COPY --from=base /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+# Dynamic linker cache
+COPY --from=base /etc/ld.so.cache /etc/ld.so.cache
+
+# Application files
 COPY ./server.py /app/server.py

--- a/examples/flask3.0-python3.10/Dockerfile
+++ b/examples/flask3.0-python3.10/Dockerfile
@@ -1,12 +1,14 @@
-FROM python:3.10.11 AS base
+FROM python:3.10.18-bookworm AS base
 
 WORKDIR /app
 
 COPY requirements.txt /app
-
 RUN pip3 install -r requirements.txt --no-cache-dir
 
 FROM scratch
 
+# Python libraries
 COPY --from=base /usr/local/lib/python3.10 /usr/local/lib/python3.10
+
+# Application files
 COPY ./server.py /app/server.py

--- a/examples/flask3.0-python3.12-base/Dockerfile
+++ b/examples/flask3.0-python3.12-base/Dockerfile
@@ -1,39 +1,35 @@
-FROM python:3.12 AS base
-
-RUN /usr/sbin/ldconfig /usr/local/lib
+FROM python:3.12.11-bookworm AS base
 
 WORKDIR /app
 
 COPY requirements.txt /app
-
 RUN pip3 install -r requirements.txt --no-cache-dir
 
+RUN /usr/sbin/ldconfig /usr/local/lib
+
 FROM scratch
-
-# System libraries
-COPY --from=base /usr/local/lib/python3.12 /usr/local/lib/python3.12
-COPY --from=base /usr/local/bin/../lib/libpython3.12.so.1.0 /usr/local/bin/../lib/libpython3.12.so.1.0
-COPY --from=base /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
-COPY --from=base /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
-COPY --from=base /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
-COPY --from=base /lib/x86_64-linux-gnu/libutil.so.1 /lib/x86_64-linux-gnu/libutil.so.1
-COPY --from=base /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
-COPY --from=base /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
-COPY --from=base /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
-COPY --from=base /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache
-COPY --from=base /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libtinfo.so.6
-COPY --from=base /lib/terminfo/x/xterm /lib/terminfo/x/xterm
-COPY --from=base /etc/inputrc /etc/inputrc
-COPY --from=base /etc/group /etc/group
-
-# Python libraries
-COPY --from=base /usr/local/lib /usr/local/lib
-COPY --from=base /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib/x86_64-linux-gnu/libz.so.1
-COPY --from=base /etc/ld.so.cache /etc/ld.so.cache
 
 # Python executable
 COPY --from=base /usr/local/bin/python3 /usr/local/bin/python3
 
-# Python files
-COPY ./server.py /app/server.py
+# System libraries
+COPY --from=base \
+                 /lib/x86_64-linux-gnu/libc.so.6 \
+                 /lib/x86_64-linux-gnu/libdl.so.2 \
+                 /lib/x86_64-linux-gnu/libm.so.6 \
+                 /lib/x86_64-linux-gnu/libpthread.so.0 \
+                 /lib/x86_64-linux-gnu/libutil.so.1 \
+                 /lib/x86_64-linux-gnu/libz.so.1 \
+                 /lib/x86_64-linux-gnu/
 
+# Python libraries
+COPY --from=base /usr/local/lib /usr/local/lib
+
+# Dynamic linker / loader
+COPY --from=base /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+# Dynamic linker cache
+COPY --from=base /etc/ld.so.cache /etc/ld.so.cache
+
+# Application files
+COPY ./server.py /app/server.py

--- a/examples/flask3.0-python3.12-sqlite3-base/Dockerfile
+++ b/examples/flask3.0-python3.12-sqlite3-base/Dockerfile
@@ -1,46 +1,42 @@
-FROM python:3.12 AS base
-
-RUN /usr/sbin/ldconfig /usr/local/lib
+FROM python:3.12.11-bookworm AS base
 
 WORKDIR /app
 
 COPY requirements.txt /app
 RUN pip3 install -r requirements.txt --no-cache-dir
 
+RUN /usr/sbin/ldconfig /usr/local/lib
+
 COPY . /app/
 RUN python3 init_db.py
 
-
 FROM scratch
 
+# Python executable
+COPY --from=base /usr/local/bin/python3 /usr/local/bin/python3
+
 # System libraries
-COPY --from=base /usr/local/lib/python3.12 /usr/local/lib/python3.12
-COPY --from=base /usr/local/bin/../lib/libpython3.12.so.1.0 /usr/local/bin/../lib/libpython3.12.so.1.0
-COPY --from=base /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
-COPY --from=base /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
-COPY --from=base /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
-COPY --from=base /lib/x86_64-linux-gnu/libutil.so.1 /lib/x86_64-linux-gnu/libutil.so.1
-COPY --from=base /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
-COPY --from=base /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
-COPY --from=base /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
-COPY --from=base /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache
-COPY --from=base /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libtinfo.so.6
-COPY --from=base /lib/terminfo/x/xterm /lib/terminfo/x/xterm
-COPY --from=base /etc/inputrc /etc/inputrc
-COPY --from=base /etc/group /etc/group
+COPY --from=base \
+                 /lib/x86_64-linux-gnu/libc.so.6 \
+                 /lib/x86_64-linux-gnu/libdl.so.2 \
+                 /lib/x86_64-linux-gnu/libm.so.6 \
+                 /lib/x86_64-linux-gnu/libpthread.so.0 \
+                 /lib/x86_64-linux-gnu/libutil.so.1 \
+                 /lib/x86_64-linux-gnu/libz.so.1 \
+                 /lib/x86_64-linux-gnu/
 
 # Python libraries
 COPY --from=base /usr/local/lib /usr/local/lib
-COPY --from=base /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib/x86_64-linux-gnu/libz.so.1
+
+# Dynamic linker / loader
+COPY --from=base /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+# Dynamic linker cache
 COPY --from=base /etc/ld.so.cache /etc/ld.so.cache
 
-# Python executable
-COPY --from=base /usr/local/bin/python3 /usr/bin/python3
+# SQLite library
+COPY --from=base /lib/x86_64-linux-gnu/libsqlite3.so.0 /lib/x86_64-linux-gnu/libsqlite3.so.0
 
-# Python files
-COPY ./server.py /app/server.py
-
-COPY --from=base /usr/lib/x86_64-linux-gnu/libsqlite3.so.0 /usr/lib/x86_64-linux-gnu/libsqlite3.so.0
-COPY --from=base /usr/local/lib/python3.12 /usr/local/lib/python3.12
+# Application files
 COPY --from=base /app /app
-
+COPY ./server.py /app/server.py

--- a/examples/flask3.0-python3.12-sqlite3/Dockerfile
+++ b/examples/flask3.0-python3.12-sqlite3/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-bookworm AS build
+FROM python:3.12.11-bookworm AS build
 
 WORKDIR /app
 
@@ -10,6 +10,11 @@ RUN python3 init_db.py
 
 FROM scratch
 
+# SQLite library
 COPY --from=build /usr/lib/x86_64-linux-gnu/libsqlite3.so.0 /usr/lib/x86_64-linux-gnu/libsqlite3.so.0
+
+# Python libraries
 COPY --from=build /usr/local/lib/python3.12 /usr/local/lib/python3.12
+
+# Application files
 COPY --from=build /app /app

--- a/examples/flask3.0-python3.12/Dockerfile
+++ b/examples/flask3.0-python3.12/Dockerfile
@@ -1,12 +1,14 @@
-FROM python:3.12-bookworm AS base
+FROM python:3.12.11-bookworm AS base
 
 WORKDIR /app
 
 COPY requirements.txt /app
-
 RUN pip3 install -r requirements.txt --no-cache-dir
 
 FROM scratch
 
+# Python libraries
 COPY --from=base /usr/local/lib/python3.12 /usr/local/lib/python3.12
+
+# Application files
 COPY ./server.py /app/server.py


### PR DESCRIPTION
Remove missing filesystem entries from Dockerfiles for Python apps. Update the DockerHub version names. Use a single stage to copy all libraries in `/lib/x86_64-linux-gnu` and sort library files alphabetically. Split Dockerfile rules by topic and add corresponding comments.