### PR TITLE
fix(examples): Use "Bye, World!" message in Zig example

### DIFF
--- a/examples/helloworld-zig0.11/helloworld.zig
+++ b/examples/helloworld-zig0.11/helloworld.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
 
 pub fn main() !void {
-    std.debug.print("Hello, world!\n", .{});
+    std.debug.print("Bye, World!\n", .{});
 }


### PR DESCRIPTION
Use "Bye, World!" message in Zig example, to make it consistent with the other examples.