### PR TITLE
fix(Dockerfile): Add missing libzstd.so.1 to resolve ImportError

### DIFF
--- a/examples/tornado6.5.1-python3.12-base/Dockerfile
+++ b/examples/tornado6.5.1-python3.12-base/Dockerfile
@@ -20,6 +20,7 @@ COPY --from=base /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
 COPY --from=base /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
 COPY --from=base /usr/lib/x86_64-linux-gnu/libssl.so.3 /usr/lib/x86_64-linux-gnu/libssl.so.3
 COPY --from=base /usr/lib/x86_64-linux-gnu/libcrypto.so.3 /usr/lib/x86_64-linux-gnu/libcrypto.so.3
+COPY --from=base /usr/lib/x86_64-linux-gnu/libzstd.so.1 /usr/lib/x86_64-linux-gnu/libzstd.so.1
 
 # Python executable
 COPY --from=base /usr/local/bin/python3 /usr/local/bin/python3


### PR DESCRIPTION
This fix targets the `tornado6.5.1-python3.12-base` example, where Python 3.12 fails to load the `ssl` module due to a missing dependency: `libzstd.so.1`.

Adding this shared library in the final Docker image resolves the ImportError and allows the Tornado HTTPServer to start correctly.