### PR TITLE
fix(examples): Fix python path in Kraftfile

### DIFF
--- a/examples/flask3.0-python3.12-sqlite3-base/Kraftfile
+++ b/examples/flask3.0-python3.12-sqlite3-base/Kraftfile
@@ -6,4 +6,4 @@ runtime: base:latest
 
 rootfs: ./Dockerfile
 
-cmd: ["/usr/bin/python3", "/app/server.py"]
+cmd: ["/usr/local/bin/python3", "/app/server.py"]


### PR DESCRIPTION
Update path to python3 executable for flask3.0-python3.12-sqlite3-base to fix `python3: Failed to execute` error.