### PR TITLE
feat(examples): Add httpserver-python3.14-base example

### DIFF
--- a/examples/httpserver-python3.14-base/Dockerfile
+++ b/examples/httpserver-python3.14-base/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.14 AS base
+
+FROM scratch
+
+# System libraries
+COPY --from=base /usr/local/lib/python3.14 /usr/local/lib/python3.14
+COPY --from=base /usr/local/bin/../lib/libpython3.14.so.1.0 /usr/local/bin/../lib/libpython3.14.so.1.0
+COPY --from=base /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=base /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=base /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=base /lib/x86_64-linux-gnu/libutil.so.1 /lib/x86_64-linux-gnu/libutil.so.1
+COPY --from=base /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=base /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=base /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+
+# Python executable
+COPY --from=base /usr/local/bin/python3 /usr/local/bin/python3
+
+# Python file
+COPY ./server.py /server.py

--- a/examples/httpserver-python3.14-base/Kraftfile
+++ b/examples/httpserver-python3.14-base/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-python3.14-base
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/local/bin/python3", "/server.py"]

--- a/examples/httpserver-python3.14-base/README.md
+++ b/examples/httpserver-python3.14-base/README.md
@@ -1,0 +1,64 @@
+# Python HTTP Server
+
+This directory contains a [Python](https://www.python.org/) HTTP server running on Unikraft that provides a simple response to each request.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 256M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME                      KERNEL                          ARGS        CREATED         STATUS   MEM   PORTS                   PLAT
+inspiring_davidgreybeard  oci://unikraft.org/python:3.14  /server.py  16 seconds ago  running  244M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `inspiring_dadidgreybeard`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm inspiring_dadidgreybeard
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 512M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/examples/httpserver-python3.14-base/server.py
+++ b/examples/httpserver-python3.14-base/server.py
@@ -1,0 +1,31 @@
+import argparse
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class MyServer(BaseHTTPRequestHandler):
+  def do_GET(self):
+    self.send_response(200)
+    self.send_header("Content-type", "text/html")
+    self.end_headers()
+    self.wfile.write(bytes("Bye, World!", "utf-8"))
+
+def main(args):
+  server = HTTPServer((args.host, args.port), MyServer)
+
+  print("starting server at %s:%s" % (args.host, args.port))
+
+  try:
+    server.serve_forever()
+
+  except KeyboardInterrupt:
+    pass
+
+  print("server stopped")
+
+def parse_args():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--host", type=str, default="0.0.0.0")
+  parser.add_argument("--port", type=int, default=8080)
+  return parser.parse_args()
+
+if __name__ == "__main__":
+  main(parse_args())


### PR DESCRIPTION
Changes:
- server.py updated for Python 3.14
- Dockerfile updated to copy the correct Python 3.14 libraries
- Kraftfile updated for Python 3.14
- README.md instructions updated