### PR TITLE
feat(examples): Add httpserver-gcc15.2 example

### DIFF
--- a/examples/httpserver-gcc13.2/http_server.c
+++ b/examples/httpserver-gcc13.2/http_server.c
@@ -13,7 +13,7 @@
 #define LISTEN_PORT 8080
 static const char reply[] = "HTTP/1.1 200 OK\r\n" \
 			    "Content-Type: text/html\r\n" \
-			    "Content-Length: 14\r\n" \
+			    "Content-Length: 12\r\n" \
 			    "Connection: close\r\n" \
 			    "\r\n" \
 			    "Bye, World!\n";

--- a/examples/httpserver-gcc15.2/Dockerfile
+++ b/examples/httpserver-gcc15.2/Dockerfile
@@ -1,0 +1,17 @@
+FROM gcc:15.2 AS build
+
+WORKDIR /src
+
+COPY ./http_server.c /src/http_server.c
+
+RUN set -xe; \
+    gcc \
+	-Wall -Wextra \
+	-fPIC -pie \
+	-o /http_server http_server.c
+
+FROM scratch
+
+COPY --from=build /http_server /http_server
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/

--- a/examples/httpserver-gcc15.2/Kraftfile
+++ b/examples/httpserver-gcc15.2/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-gcc15.2
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/http_server"]

--- a/examples/httpserver-gcc15.2/README.md
+++ b/examples/httpserver-gcc15.2/README.md
@@ -1,0 +1,64 @@
+# C HTTP Web Server
+
+This directory contains a C HTTP server running on Unikraft.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME             KERNEL                          ARGS          CREATED       STATUS   MEM  PORTS                   PLAT
+kind_johndaniel  oci://unikraft.org/base:latest  /http_server  1 second ago  running  64M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `kind_johndanielg`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm kind_johndanielg
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 256M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-gcc15.2/http_server.c
+++ b/examples/httpserver-gcc15.2/http_server.c
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2023, Unikraft GmbH and the Unikraft Authors.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <errno.h>
+
+#define LISTEN_PORT 8080
+static const char reply[] = "HTTP/1.1 200 OK\r\n" \
+			    "Content-Type: text/html\r\n" \
+			    "Content-Length: 12\r\n" \
+			    "Connection: close\r\n" \
+			    "\r\n" \
+			    "Bye, World!\n";
+
+#define BUFLEN 2048
+static char recvbuf[BUFLEN];
+
+int main(int argc __attribute__((unused)),
+	 char *argv[] __attribute__((unused)))
+{
+	int rc = 0;
+	int srv, client;
+	ssize_t n;
+	struct sockaddr_in srv_addr;
+
+	srv = socket(AF_INET, SOCK_STREAM, 0);
+	if (srv < 0) {
+		fprintf(stderr, "Failed to create socket: %d\n", errno);
+		goto out;
+	}
+
+	srv_addr.sin_family = AF_INET;
+	srv_addr.sin_addr.s_addr = INADDR_ANY;
+	srv_addr.sin_port = htons(LISTEN_PORT);
+
+	rc = bind(srv, (struct sockaddr *) &srv_addr, sizeof(srv_addr));
+	if (rc < 0) {
+		fprintf(stderr, "Failed to bind socket: %d\n", errno);
+		goto out;
+	}
+
+	/* Accept one simultaneous connection */
+	rc = listen(srv, 1);
+	if (rc < 0) {
+		fprintf(stderr, "Failed to listen on socket: %d\n", errno);
+		goto out;
+	}
+
+	printf("Listening on port %d...\n", LISTEN_PORT);
+	while (1) {
+		client = accept(srv, NULL, 0);
+		if (client < 0) {
+			fprintf(stderr,
+				"Failed to accept incoming connection: %d\n",
+				errno);
+			goto out;
+		}
+
+		/* Receive some bytes (ignore errors) */
+		read(client, recvbuf, BUFLEN);
+
+		/* Send reply */
+		n = write(client, reply, sizeof(reply) - 1);
+		if (n < 0)
+			fprintf(stderr, "Failed to send a reply\n");
+		else
+			printf("Sent a reply\n");
+
+		/* Close connection */
+		close(client);
+	}
+
+out:
+	return rc;
+}


### PR DESCRIPTION
### Summary
This PR addresses a bug in the existing HTTP server example and introduces a new variant using the latest stable GCC version.

### Changes
1. **fix(examples/httpserver-gcc13.2):** Corrected a `Content-Length` header mismatch.
   - The header was previously set to `14`, but the actual payload (`"Bye, World!\n"`) is `12` bytes.
   - This caused HTTP clients (like browsers) to hang or timeout while waiting for the expected extra bytes.
   - The value has been updated to `12` to match the payload.

2. **feat(examples):** Added `httpserver-gcc15.2`.
   - Introduced a new example variant based on `gcc:15.2`.
   - Updated the `Dockerfile` to correctly copy the required shared libraries (libc, ld-linux) specific to the newer GCC environment.

### Testing
- Verified that `httpserver-gcc13.2` now responds instantly to browser requests without timing out.
- Verified that the new `httpserver-gcc15.2` builds and runs successfully using `kraft run`.