### PR TITLE
feat(examples): Add httpserver-g++15.2 example

### DIFF
--- a/examples/httpserver-g++15.2/Dockerfile
+++ b/examples/httpserver-g++15.2/Dockerfile
@@ -1,0 +1,24 @@
+FROM gcc:15.2.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./http_server.cpp /src/http_server.cpp
+
+RUN set -xe; \
+    g++ \
+	-Wall -Wextra \
+	-fPIC -pie \
+	-o /http_server http_server.cpp
+
+FROM scratch
+
+# System / C++ libraries
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /usr/local/lib64/libgcc_s.so.1 /usr/local/lib64/libgcc_s.so.1
+COPY --from=build /usr/local/lib64/libstdc++.so.6 /usr/local/lib64/libstdc++.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
+
+# C++ HTTP server
+COPY --from=build /http_server /http_server

--- a/examples/httpserver-g++15.2/Kraftfile
+++ b/examples/httpserver-g++15.2/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-g++15.2
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/http_server"]

--- a/examples/httpserver-g++15.2/README.md
+++ b/examples/httpserver-g++15.2/README.md
@@ -1,0 +1,64 @@
+# C++ HTTP Web Server
+
+This directory contains a C++ HTTP server running on Unikraft.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME                    KERNEL                          ARGS          CREATED        STATUS   MEM  PORTS                   PLAT
+friendly_pierrebrassau  oci://unikraft.org/base:latest  /http_server  2 minutes ago  running  64M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `friendly_pierrebrassau`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm friendly_pierrebrassau
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 256M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-g++15.2/http_server.cpp
+++ b/examples/httpserver-g++15.2/http_server.cpp
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2023, Unikraft GmbH and the Unikraft Authors.
+ */
+
+#include <iostream>
+#include <cstring>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <errno.h>
+
+#define LISTEN_PORT 8080
+
+static std::string reply = "HTTP/1.1 200 OK\r\n" \
+			    "Content-Type: text/html\r\n" \
+			    "Content-Length: 12\r\n" \
+			    "Connection: close\r\n" \
+			    "\r\n" \
+			    "Bye, World!\n";
+
+#define BUFLEN 2048
+static char recvbuf[BUFLEN];
+
+int main(int argc __attribute__((unused)),
+	 char *argv[] __attribute__((unused)))
+{
+	int rc = 0;
+	int srv, client;
+	ssize_t n;
+	struct sockaddr_in srv_addr;
+
+	srv = socket(AF_INET, SOCK_STREAM, 0);
+	if (srv < 0) {
+		std::cerr << "Failed to create socket: " << errno << std::endl;
+		goto out;
+	}
+
+	srv_addr.sin_family = AF_INET;
+	srv_addr.sin_addr.s_addr = INADDR_ANY;
+	srv_addr.sin_port = htons(LISTEN_PORT);
+
+	rc = bind(srv, (struct sockaddr *) &srv_addr, sizeof(srv_addr));
+	if (rc < 0) {
+		std::cerr << "Failed to bind socket: " << errno << std::endl;
+		goto out;
+	}
+
+	/* Accept one simultaneous connection */
+	rc = listen(srv, 1);
+	if (rc < 0) {
+		std::cerr << "Failed to listen on socket: " << errno << std::endl;
+		goto out;
+	}
+
+	std::cout << "Listening on port " << LISTEN_PORT << std::endl;
+	while (1) {
+		client = accept(srv, NULL, 0);
+		if (client < 0) {
+			std::cerr << "Failed to accept incoming connection: " << errno << std::endl;
+			goto out;
+		}
+
+		/* Receive some bytes (ignore errors) */
+		read(client, recvbuf, BUFLEN);
+
+		/* Send reply */
+		n = write(client, reply.c_str(), reply.length());
+		if (n < 0)
+			std::cerr << "Failed to send reply" << std::endl;
+		else
+			std::cout << "Sent a reply" << std::endl;
+
+		/* Close connection */
+		close(client);
+	}
+
+out:
+	return rc;
+}


### PR DESCRIPTION
This PR introduces a fully functional httpserver-g++15.2 example and includes several improvements required to make the application run correctly.

### **Changes included** ###

Added the new httpserver-g++15.2 example directory.

Updated the Dockerfile to correctly build and package the example.

Updated the Kraftfile with the required configuration for running the server using GCC 15.2.

Fixed an HTTP response issue by adjusting the Content-Length header from 14 to 12, ensuring the response is parsed correctly by clients.

### **Testing** ###

Successfully built the image using KraftKit.

Verified that the server listens on port 8080.

Confirmed that the HTTP response is correctly returned via curl and browser access.

Confirmed that repeated requests are handled properly, and log output shows "Sent a reply".

### **Result** ###

The example now compiles and runs without issues, providing a simple and correct HTTP server implementation using g++ 15.2 on Unikraft.