### PR TITLE
feat(examples): Add helloworld-g++15.2 example

### DIFF
--- a/examples/helloworld-g++15.2/Dockerfile
+++ b/examples/helloworld-g++15.2/Dockerfile
@@ -1,0 +1,24 @@
+FROM gcc:15.2.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./helloworld.cpp /src/helloworld.cpp
+
+RUN set -xe; \
+    g++ \
+	-Wall -Wextra \
+	-fPIC -pie \
+	-o /helloworld helloworld.cpp
+
+FROM scratch
+
+# System / C++ libraries
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /usr/local/lib64/libgcc_s.so.1 /usr/local/lib64/libgcc_s.so.1
+COPY --from=build /usr/local/lib64/libstdc++.so.6 /usr/local/lib64/libstdc++.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
+
+# C++ HTTP server
+COPY --from=build /helloworld /helloworld

--- a/examples/helloworld-g++15.2/Kraftfile
+++ b/examples/helloworld-g++15.2/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: helloworld-g++15.2
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/helloworld"]

--- a/examples/helloworld-g++15.2/README.md
+++ b/examples/helloworld-g++15.2/README.md
@@ -1,0 +1,57 @@
+# C++ "Hello, World!"
+
+This directory contains a C++-based "Hello, World!" example running on Unikraft.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm --plat qemu --arch x86_64 .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, you should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME            KERNEL                          ARGS         CREATED        STATUS   MEM  PORTS  PLAT
+elastic_goblin  oci://unikraft.org/base:latest  /helloworld  9 seconds ago  running  64M         qemu/x86_64
+```
+
+The instance name is `elastic_goblin`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm elastic_goblin
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm --plat qemu --arch x86_64 -M 256M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/helloworld-g++15.2/helloworld.cpp
+++ b/examples/helloworld-g++15.2/helloworld.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+int main()
+{
+	std::cout << "Bye, World!" << std::endl;
+
+	return 0;
+}


### PR DESCRIPTION
This PR adds a minimal helloworld example compiled with g++ 15.2, intended as a simple reference application for testing build configurations with the updated GCC toolchain.

### Changes included ###

Added new helloworld-g++15.2 example directory.

Implemented a minimal C++ program that prints "Bye, World!".

Updated the Dockerfile to build this example correctly.

Updated the Kraftfile with the required settings for GCC 15.2.

Ensured that the example builds and runs successfully under Unikraft.

### Testing ###

Successfully built the example with KraftKit.

Confirmed that it runs correctly and outputs:

```bash
Bye, World!
```
### Result ###

This example provides a clean and compact baseline for verifying C++ application support under g++ 15.2 on Unikraft.