### PR TITLE
fix(examples): Pin hugo runtime to version 0.122

### DIFF
--- a/examples/hugo0.122/Kraftfile
+++ b/examples/hugo0.122/Kraftfile
@@ -2,7 +2,7 @@ spec: v0.6
 
 name: hugo0.122
 
-runtime: hugo:latest
+runtime: hugo:0.122
 
 rootfs: ./Dockerfile
 

--- a/examples/hugo0.122/README.md
+++ b/examples/hugo0.122/README.md
@@ -36,7 +36,7 @@ kraft ps
 
 ```text
 NAME         KERNEL                          ARGS                                                CREATED        STATUS   MEM   PORTS                   PLAT
-loving_moja  oci://unikraft.org/hugo:latest  /usr/bin/hugo server --bind=0.0.0.0 --source /site  3 seconds ago  running  488M  0.0.0.0:1313->1313/tcp  qemu/x86_64
+loving_moja  oci://unikraft.org/hugo:0.122  /usr/bin/hugo server --bind=0.0.0.0 --source /site  3 seconds ago  running  488M  0.0.0.0:1313->1313/tcp  qemu/x86_64
 ```
 
 The instance name is `loving_moja`.


### PR DESCRIPTION
The `hugo:latest` tag is unavailable in the Unikraft registry causing  `could not find runtime hugo:latest` error during the build phase. Pinning runtime verion  to `0.122` fixes the issue.