### PR TITLE
fix(library): Update `brk` config after move to posix-process

### DIFF
--- a/library/base/Kraftfile
+++ b/library/base/Kraftfile
@@ -14,7 +14,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC: 'y'

--- a/library/bun/1.1/Kraftfile
+++ b/library/bun/1.1/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/caddy/2.10/Kraftfile
+++ b/library/caddy/2.10/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/caddy/2.7/Kraftfile
+++ b/library/caddy/2.7/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/dragonfly/1.14/Kraftfile
+++ b/library/dragonfly/1.14/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/findtime/Kraftfile
+++ b/library/findtime/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/grafana/10.2/Kraftfile
+++ b/library/grafana/10.2/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/haproxy/2.8/Kraftfile
+++ b/library/haproxy/2.8/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/httpbingo/2.13.4/Kraftfile
+++ b/library/httpbingo/2.13.4/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/hugo/0.122/Kraftfile
+++ b/library/hugo/0.122/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/imaginary/1.2/Kraftfile
+++ b/library/imaginary/1.2/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/java/17/Kraftfile
+++ b/library/java/17/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/lua/5.4.4/Kraftfile
+++ b/library/lua/5.4.4/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/mariadb/11.2/Kraftfile
+++ b/library/mariadb/11.2/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/memcached/1.6/Kraftfile
+++ b/library/memcached/1.6/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/mongo/6.0/Kraftfile
+++ b/library/mongo/6.0/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/nats/2.10/Kraftfile
+++ b/library/nats/2.10/Kraftfile
@@ -21,7 +21,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/nginx/1.25/Kraftfile
+++ b/library/nginx/1.25/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/node/18/Kraftfile
+++ b/library/node/18/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/node/19/Kraftfile
+++ b/library/node/19/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/node/20/Kraftfile
+++ b/library/node/20/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/node/21/Kraftfile
+++ b/library/node/21/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/perl/5.38/Kraftfile
+++ b/library/perl/5.38/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/perl/5.42/Kraftfile
+++ b/library/perl/5.42/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/php/8.2/Kraftfile
+++ b/library/php/8.2/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/python/3.12/Kraftfile
+++ b/library/python/3.12/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/python/3.13/Kraftfile
+++ b/library/python/3.13/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/python/3.14/Kraftfile
+++ b/library/python/3.14/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/r/4.3.3/Kraftfile
+++ b/library/r/4.3.3/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 1024
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/redis/7.2/Kraftfile
+++ b/library/redis/7.2/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/ruby/3.2/Kraftfile
+++ b/library/ruby/3.2/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/skipper/0.18/Kraftfile
+++ b/library/skipper/0.18/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'

--- a/library/surreal/1.1/Kraftfile
+++ b/library/surreal/1.1/Kraftfile
@@ -17,7 +17,7 @@ unikraft:
     # Configurations options for app-elfloader
     # (they can't be part of the template atm)
     CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-    CONFIG_APPELFLOADER_BRK: 'y'
+    CONFIG_LIBPOSIX_PROCESS_BRK: 'y'
     CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
     CONFIG_APPELFLOADER_STACK_NBPAGES: 128
     CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'


### PR DESCRIPTION
The `brk` implementation has been moved from elfloader to the core repository into the posix-process library. CONFIG_APPELFLOADER_BRK -> CONFIG_LIBPOSIX_PROCESS_BRK