### PR TITLE
Added an example for an http server using nodejs25.

### DIFF
--- a/examples/httpserver-nodejs25-base/.dockerignore
+++ b/examples/httpserver-nodejs25-base/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-nodejs25-base/.gitignore
+++ b/examples/httpserver-nodejs25-base/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-nodejs25-base/Dockerfile
+++ b/examples/httpserver-nodejs25-base/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:25-alpine3.22 AS node
+
+FROM alpine:3.22 AS sys
+
+RUN set -xe; \
+    mkdir -p /target/etc; \
+    mkdir -p /blank; \
+    apk --no-cache add \
+    ca-certificates \
+    tzdata \
+    ; \
+    update-ca-certificates; \
+    ln -sf ../usr/share/zoneinfo/Etc/UTC /target/etc/localtime; \
+    echo "Etc/UTC" > /target/etc/timezone;
+
+FROM scratch
+
+COPY --from=sys /target/etc /etc
+COPY --from=sys /usr/share/zoneinfo/Etc/UTC /usr/share/zoneinfo/Etc/UTC
+COPY --from=sys /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=sys /blank /tmp
+
+# Node binary
+COPY --from=node /usr/local/bin/node /usr/bin/node
+
+# System libraries
+COPY --from=node /etc/ssl/openssl.cnf /etc/ssl/openssl.cnf
+COPY --from=node /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=node /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=node /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+
+# Node HTTP server
+COPY ./src /usr/src

--- a/examples/httpserver-nodejs25-base/Kraftfile
+++ b/examples/httpserver-nodejs25-base/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-nodejs25-base
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/httpserver-nodejs25-base/README.md
+++ b/examples/httpserver-nodejs25-base/README.md
@@ -1,0 +1,64 @@
+# Node 25 Web Server
+
+This directory contains a [Node](https://nodejs.org/en) web server running on Unikraft.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 1024M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME             KERNEL                      ARGS                              CREATED         STATUS   MEM   PORTS                   PLAT
+unruffled_edgar  oci://unikraft.org/node:25  /usr/bin/node /usr/src/server.js  47 seconds ago  running  488M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `unruffled_edgar`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm unruffled_edgar
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run -p 8080:8080 --plat qemu --arch x86_64 -M 2048M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-nodejs25-base/src/server.js
+++ b/examples/httpserver-nodejs25-base/src/server.js
@@ -1,0 +1,15 @@
+const http = require('http');
+
+const server = http.createServer((req, resp) => {
+  resp.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  resp.write('Bye, World!\n');
+
+  resp.end();
+})
+
+server.listen(8080, "0.0.0.0", () => {
+  console.log(`Listening on :8080...`);
+});


### PR DESCRIPTION
# Description

Added an example for an HTTP server using NodeJS 25.

# Changes

- Created a new directory `examples/httpserver-nodejs25-base`.
- Added `Kraftfile` and `Dockerfile` for version 25.
- Added a `README.md` with instructions for running the example, consistent with previous examples.

# Testing

- Verified the execution using `kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 1024M .`
- Server responds correctly on localhost, `curl localhost:8080` responds with `Bye, World!`.

