### PR TITLE
add run & test steps to Caddy 2.7, Caddy 2.10, Httpbingo and HAProxy

### DIFF
--- a/.github/workflows/library-caddy2.10.yaml
+++ b/.github/workflows/library-caddy2.10.yaml
@@ -55,7 +55,7 @@ jobs:
         arch: ${{ matrix.arch }}
         push: false
         output: oci://index.unikraft.io/unikraft.org/caddy:2.10
-
+    
     - name: Archive OCI digests
       uses: actions/upload-artifact@v4
       with:
@@ -63,9 +63,31 @@ jobs:
         path: ${{ github.workspace }}/.kraftkit/oci/digests
         if-no-files-found: error
 
+  run:
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - plat: qemu
+            arch: x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup KraftKit
+        uses: unikraft/kraftkit@staging
+        with:
+          runtimedir: /github/workspace/.kraftkit
+      - name: Test caddy2.10
+        run: |
+          cd library/caddy/2.10
+          kraft run -d -M 512M -p 2015:2015 --plat ${{ matrix.plat }} --arch ${{ matrix.arch }}
+          sleep 10
+          curl -I http://localhost:2015 || exit 1
+          kraft stop --all
+
   push:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [ build ]
+    needs: [ run ]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/library-caddy2.7.yaml
+++ b/.github/workflows/library-caddy2.7.yaml
@@ -63,9 +63,31 @@ jobs:
         path: ${{ github.workspace }}/.kraftkit/oci/digests
         if-no-files-found: error
 
+  run:
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - plat: qemu
+            arch: x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup KraftKit
+        uses: unikraft/kraftkit@staging
+        with:
+          runtimedir: /github/workspace/.kraftkit
+      - name: Test caddy2.7
+        run: |
+          cd library/caddy/2.7
+          kraft run -d -M 512M -p 2015:2015 --plat ${{ matrix.plat }} --arch ${{ matrix.arch }}
+          sleep 10
+          curl -I http://localhost:2015 || exit 1
+          kraft stop --all
+
   push:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [ build ]
+    needs: [ run ]
     runs-on: ubuntu-latest
 
     steps:
@@ -83,3 +105,4 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/caddy:2.7
         push: true
+        

--- a/.github/workflows/library-haproxy2.8.yaml
+++ b/.github/workflows/library-haproxy2.8.yaml
@@ -58,9 +58,31 @@ jobs:
         path: ${{ github.workspace }}/.kraftkit/oci/digests
         if-no-files-found: error
 
+  run:
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - plat: qemu
+            arch: x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup KraftKit
+        uses: unikraft/kraftkit@staging
+        with:
+          runtimedir: /github/workspace/.kraftkit
+      - name: Test haproxy2.8
+        run: |
+          cd library/haproxy/2.8
+          kraft run -d -M 256M -p 8404:8404 --plat ${{ matrix.plat }} --arch ${{ matrix.arch }}
+          sleep 10
+          curl -I http://localhost:8404/stats || exit 1
+          kraft stop --all
+      
   push:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [ build ]
+    needs: [ run ]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/library-httpbingo2.13.4.yaml
+++ b/.github/workflows/library-httpbingo2.13.4.yaml
@@ -57,10 +57,31 @@ jobs:
         name: oci-digests-${{ matrix.arch }}-${{ matrix.plat }}
         path: ${{ github.workspace }}/.kraftkit/oci/digests
         if-no-files-found: error
+  run:
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - plat: qemu
+            arch: x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup KraftKit
+        uses: unikraft/kraftkit@staging
+        with:
+          runtimedir: /github/workspace/.kraftkit
+      - name: Test httpbingo2.13.4
+        run: |
+          cd library/httpbingo/2.13.4
+          kraft run -d -M 256M -p 8080:8080 --plat ${{ matrix.plat }} --arch ${{ matrix.arch }}
+          sleep 10
+          curl -I http://localhost:8080/status/418 || exit 1
+          kraft stop --all
 
   push:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [ build ]
+    needs: [ run ]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/library-surreal1.1.yaml
+++ b/.github/workflows/library-surreal1.1.yaml
@@ -24,6 +24,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Caddy 2.7 Am adăugat un pas de testare care pornește unikernel-ul în background  și validează cu curl pe portul 2015 că serverul web se inițializează și răspunde corect.

Caddy 2.10 Am implementat aceeași validare automată cu curl pe portul 2015 și 512MB RAM, pentru a garanta că și această versiune rulează fără probleme.

Httpbingo 2.13.4: Am inclus un pas de validare pe portul 8080, verificând endpoint-ul /status/418 pentru a confirma că aplicația Go pornește corect și răspunde la cereri în mediul Unikraft.

HAProxy 2.8: Am adăugat testarea automată pentru pagina de statistici pe portul 8404, asigurând funcționarea corectă a serviciului cu o alocare de 256MB RAM.
