### PR TITLE
test: add validation job for mongo:6.0

### DIFF
--- a/.github/workflows/library-mongo6.0.yaml
+++ b/.github/workflows/library-mongo6.0.yaml
@@ -5,7 +5,7 @@ on:
   - cron: '0 1 * * *'
 
   push:
-    branches: [main]
+    branches: [main, The-TallGuy/add-mongo-test]
     paths:
     - 'library/mongo/6.0/**'
     - '.github/workflows/library-mongo6.0.yaml'

--- a/.github/workflows/library-mongo6.0.yaml
+++ b/.github/workflows/library-mongo6.0.yaml
@@ -103,38 +103,30 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Download OCI layout from build
-      uses: actions/download-artifact@v4
+    - name: Setup KraftKit and Dependencies
+      uses: unikraft/kraftkit@staging
       with:
-        name: oci-layout-${{ matrix.arch }}-${{ matrix.plat }}
-        path: ${{ github.workspace }}/.kraftkit/oci
+        loglevel: debug
 
-    - name: Install system dependencies for KraftKit
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y qemu-system-x86 qemu-utils socat
-
-    - name: Install KraftKit
-      run: curl -sSfL https://get.kraftkit.sh | sudo sh -s -- -y
+    - name: Install netcat
+      run: sudo apt-get update && sudo apt-get install -y netcat-openbsd
 
     - name: Run mongo6.0 (${{ matrix.plat }}/${{ matrix.arch }})
-      env:
-        KRAFTKIT_RUNTIME_DIR: ${{ github.workspace }}/.kraftkit
-        KRAFTKIT_NO_CHECK_UPDATES: true
       run: |
-        kraft run --rm -M 1024M -p 27017:27017 --plat ${{ matrix.plat }} --arch ${{ matrix.arch }} index.unikraft.io/unikraft.org/mongo:6.0 &
+        cd library/mongo/6.0
+        kraft run --rm -M 1024M -p 27017:27017 --plat ${{ matrix.plat }} --arch ${{ matrix.arch }} . &
         echo $! > /tmp/kraft_pid
 
     - name: Wait for port 27017
       run: |
-        for i in $(seq 1 15); do
+        for i in $(seq 1 30); do
           if nc -z 127.0.0.1 27017; then
-            echo "Mongo on ${{ matrix.plat }} accepted the connection."
+            echo "Mongo pe ${{ matrix.plat }} a acceptat conexiunea."
             exit 0
           fi
           sleep 1
         done
-        echo "Mongo did not answer after 15 seconds."
+        echo "Mongo nu a răspuns după 30 secunde."
         exit 1
 
     - name: Stop mongo instance

--- a/.github/workflows/library-mongo6.0.yaml
+++ b/.github/workflows/library-mongo6.0.yaml
@@ -112,6 +112,7 @@ jobs:
     - name: Install KraftKit
       run: |
         curl -sSfL https://get.kraftkit.sh | sh -s -- -y
+        echo "$HOME/.kraftkit/bin" >> $GITHUB_PATH
 
     - name: Run mongo6.0 (${{ matrix.plat }}/${{ matrix.arch }})
       env:

--- a/.github/workflows/library-mongo6.0.yaml
+++ b/.github/workflows/library-mongo6.0.yaml
@@ -60,13 +60,6 @@ jobs:
         path: ${{ github.workspace }}/.kraftkit/oci/digests
         if-no-files-found: error
 
-    - name: Archive OCI layout
-      uses: actions/upload-artifact@v4
-      with:
-        name: oci-layout-${{ matrix.arch }}-${{ matrix.plat }}
-        path: ${{ github.workspace }}/.kraftkit/oci
-        if-no-files-found: error
-
   push:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
     needs: [ build ]
@@ -96,49 +89,39 @@ jobs:
         include:
         - plat: qemu
           arch: x86_64
-        - plat: fc
-          arch: x86_64
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Download OCI layout from build
-      uses: actions/download-artifact@v4
-      with:
-        name: oci-layout-${{ matrix.arch }}-${{ matrix.plat }}
-        path: ${{ github.workspace }}/.kraftkit/oci
-
-    - name: Install netcat
-      run: sudo apt-get update && sudo apt-get install -y netcat-openbsd
-
-    - name: Install system dependencies for KraftKit
+    - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y qemu-system-x86 qemu-utils socat
+        sudo apt-get install -y qemu-system-x86 qemu-utils socat netcat-openbsd
 
     - name: Install KraftKit
       run: curl -sSfL https://get.kraftkit.sh | sudo sh -s -- -y
 
-    - name: Run mongo6.0 (${{ matrix.plat }}/${{ matrix.arch }})
+    - name: Build and Run mongo6.0
       env:
-        KRAFTKIT_RUNTIME_DIR: ${{ github.workspace }}/.kraftkit
         KRAFTKIT_NO_CHECK_UPDATES: true
       run: |
         cd library/mongo/6.0
-        kraft run --rm -M 1024M -p 27017:27017 --plat ${{ matrix.plat }} --arch ${{ matrix.arch }} . &
+        kraft build --plat ${{ matrix.plat }} --arch ${{ matrix.arch }}
+        kraft run --rm -W -M 4096M -p 27017:27017 --plat ${{ matrix.plat }} --arch ${{ matrix.arch }} . > /tmp/kraft-mongo.log 2>&1 &
         echo $! > /tmp/kraft_pid
 
     - name: Wait for port 27017
       run: |
-        for i in $(seq 1 30); do
+        for i in $(seq 1 120); do
           if nc -z 127.0.0.1 27017; then
             echo "Mongo on ${{ matrix.plat }} accepted the connection."
             exit 0
           fi
           sleep 1
         done
-        echo "Mongo did not answer after 15 seconds."
+        echo "Mongo did not answer after 120 seconds."
+        cat /tmp/kraft-mongo.log || true
         exit 1
 
     - name: Stop mongo instance

--- a/.github/workflows/library-mongo6.0.yaml
+++ b/.github/workflows/library-mongo6.0.yaml
@@ -103,15 +103,27 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup KraftKit and Dependencies
-      uses: unikraft/kraftkit@staging
+    - name: Download OCI layout from build
+      uses: actions/download-artifact@v4
       with:
-        loglevel: debug
+        name: oci-layout-${{ matrix.arch }}-${{ matrix.plat }}
+        path: ${{ github.workspace }}/.kraftkit/oci
 
     - name: Install netcat
       run: sudo apt-get update && sudo apt-get install -y netcat-openbsd
 
+    - name: Install system dependencies for KraftKit
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y qemu-system-x86 qemu-utils socat
+
+    - name: Install KraftKit
+      run: curl -sSfL https://get.kraftkit.sh | sudo sh -s -- -y
+
     - name: Run mongo6.0 (${{ matrix.plat }}/${{ matrix.arch }})
+      env:
+        KRAFTKIT_RUNTIME_DIR: ${{ github.workspace }}/.kraftkit
+        KRAFTKIT_NO_CHECK_UPDATES: true
       run: |
         cd library/mongo/6.0
         kraft run --rm -M 1024M -p 27017:27017 --plat ${{ matrix.plat }} --arch ${{ matrix.arch }} . &
@@ -121,12 +133,12 @@ jobs:
       run: |
         for i in $(seq 1 30); do
           if nc -z 127.0.0.1 27017; then
-            echo "Mongo pe ${{ matrix.plat }} a acceptat conexiunea."
+            echo "Mongo on ${{ matrix.plat }} accepted the connection."
             exit 0
           fi
           sleep 1
         done
-        echo "Mongo nu a răspuns după 30 secunde."
+        echo "Mongo did not answer after 15 seconds."
         exit 1
 
     - name: Stop mongo instance

--- a/.github/workflows/library-mongo6.0.yaml
+++ b/.github/workflows/library-mongo6.0.yaml
@@ -83,30 +83,45 @@ jobs:
 
   test:
     needs: [ build ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - plat: qemu
+          arch: x86_64
+        - plat: fc
+          arch: x86_64
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
 
+    - name: Setup KraftKit
+      uses: unikraft/kraftkit@staging
+      with:
+        loglevel: debug
+
     - name: Install netcat
       run: sudo apt-get update && sudo apt-get install -y netcat-openbsd
 
-    - name: Run mongo6.0 (qemu/x86_64)
+    - name: Run mongo6.0 (${{ matrix.plat }}/${{ matrix.arch }})
       run: |
         cd library/mongo/6.0
-        kraft run --rm -M 1024M -p 27017:27017 --plat qemu --arch x86_64 . &
+        # Aici kraft va rula aplicația, iar dacă nu o găsește gata compilată, 
+        # o va recompila rapid local pe mașina de test înainte să o pornească.
+        kraft run --rm -M 1024M -p 27017:27017 --plat ${{ matrix.plat }} --arch ${{ matrix.arch }} . &
         echo $! > /tmp/kraft_pid
 
     - name: Wait for port 27017
       run: |
         for i in $(seq 1 15); do
           if nc -z 127.0.0.1 27017; then
-            echo "Mongo is accepting connections."
+            echo "Mongo pe ${{ matrix.plat }} a acceptat conexiunea."
             exit 0
           fi
           sleep 1
         done
-        echo "Mongo did not accept connections after 15 seconds."
+        echo "Mongo nu a răspuns după 15 secunde."
         exit 1
 
     - name: Stop mongo instance

--- a/.github/workflows/library-mongo6.0.yaml
+++ b/.github/workflows/library-mongo6.0.yaml
@@ -109,6 +109,11 @@ jobs:
         name: oci-layout-${{ matrix.arch }}-${{ matrix.plat }}
         path: ${{ github.workspace }}/.kraftkit/oci
 
+    - name: Install system dependencies for KraftKit
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y qemu-system-x86 qemu-utils socat
+
     - name: Install KraftKit
       run: |
         curl -sSfL https://get.kraftkit.sh | sudo sh -s -- -y

--- a/.github/workflows/library-mongo6.0.yaml
+++ b/.github/workflows/library-mongo6.0.yaml
@@ -78,3 +78,38 @@ jobs:
       with:
         name: index.unikraft.io/unikraft.org/mongo:6.0
         push: true
+
+  test:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install netcat
+      run: sudo apt-get update && sudo apt-get install -y netcat-openbsd
+
+    - name: Run mongo6.0 (qemu/x86_64)
+      run: |
+        cd library/mongo/6.0
+        kraft run --rm -M 1024M -p 27017:27017 --plat qemu --arch x86_64 . &
+        echo $! > /tmp/kraft_pid
+
+    - name: Wait for port 27017
+      run: |
+        for i in $(seq 1 15); do
+          if nc -z 127.0.0.1 27017; then
+            echo "Mongo is accepting connections."
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "Mongo did not accept connections after 15 seconds."
+        exit 1
+
+    - name: Stop mongo instance
+      if: ${{ always() }}
+      run: |
+        if [ -f /tmp/kraft_pid ]; then
+          kill "$(cat /tmp/kraft_pid)" || true
+        fi

--- a/.github/workflows/library-mongo6.0.yaml
+++ b/.github/workflows/library-mongo6.0.yaml
@@ -60,6 +60,13 @@ jobs:
         path: ${{ github.workspace }}/.kraftkit/oci/digests
         if-no-files-found: error
 
+    - name: Archive OCI layout
+      uses: actions/upload-artifact@v4
+      with:
+        name: oci-layout-${{ matrix.arch }}-${{ matrix.plat }}
+        path: ${{ github.workspace }}/.kraftkit/oci
+        if-no-files-found: error
+
   push:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
     needs: [ build ]
@@ -96,32 +103,34 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup KraftKit
-      uses: unikraft/kraftkit@staging
+    - name: Download OCI layout from build
+      uses: actions/download-artifact@v4
       with:
-        loglevel: debug
+        name: oci-layout-${{ matrix.arch }}-${{ matrix.plat }}
+        path: ${{ github.workspace }}/.kraftkit/oci
 
-    - name: Install netcat
-      run: sudo apt-get update && sudo apt-get install -y netcat-openbsd
+    - name: Install KraftKit
+      run: |
+        curl -sSfL https://get.kraftkit.sh | sh -s -- -y
 
     - name: Run mongo6.0 (${{ matrix.plat }}/${{ matrix.arch }})
+      env:
+        KRAFTKIT_RUNTIME_DIR: ${{ github.workspace }}/.kraftkit
+        KRAFTKIT_NO_CHECK_UPDATES: true
       run: |
-        cd library/mongo/6.0
-        # Aici kraft va rula aplicația, iar dacă nu o găsește gata compilată, 
-        # o va recompila rapid local pe mașina de test înainte să o pornească.
-        kraft run --rm -M 1024M -p 27017:27017 --plat ${{ matrix.plat }} --arch ${{ matrix.arch }} . &
+        kraft run --rm -M 1024M -p 27017:27017 --plat ${{ matrix.plat }} --arch ${{ matrix.arch }} index.unikraft.io/unikraft.org/mongo:6.0 &
         echo $! > /tmp/kraft_pid
 
     - name: Wait for port 27017
       run: |
         for i in $(seq 1 15); do
           if nc -z 127.0.0.1 27017; then
-            echo "Mongo pe ${{ matrix.plat }} a acceptat conexiunea."
+            echo "Mongo on ${{ matrix.plat }} accepted the connection."
             exit 0
           fi
           sleep 1
         done
-        echo "Mongo nu a răspuns după 15 secunde."
+        echo "Mongo did not answer after 15 seconds."
         exit 1
 
     - name: Stop mongo instance

--- a/.github/workflows/library-mongo6.0.yaml
+++ b/.github/workflows/library-mongo6.0.yaml
@@ -111,7 +111,7 @@ jobs:
 
     - name: Install KraftKit
       run: |
-        curl -sSfL https://get.kraftkit.sh | sh -s -- -y
+        curl -sSfL https://get.kraftkit.sh | sudo sh -s -- -y
         sudo mv ~/.kraftkit/bin/kraft /usr/local/bin/kraft
 
     - name: Run mongo6.0 (${{ matrix.plat }}/${{ matrix.arch }})

--- a/.github/workflows/library-mongo6.0.yaml
+++ b/.github/workflows/library-mongo6.0.yaml
@@ -115,9 +115,7 @@ jobs:
         sudo apt-get install -y qemu-system-x86 qemu-utils socat
 
     - name: Install KraftKit
-      run: |
-        curl -sSfL https://get.kraftkit.sh | sudo sh -s -- -y
-        sudo mv ~/.kraftkit/bin/kraft /usr/local/bin/kraft
+      run: curl -sSfL https://get.kraftkit.sh | sudo sh -s -- -y
 
     - name: Run mongo6.0 (${{ matrix.plat }}/${{ matrix.arch }})
       env:

--- a/.github/workflows/library-mongo6.0.yaml
+++ b/.github/workflows/library-mongo6.0.yaml
@@ -18,6 +18,8 @@ on:
     - 'library/mongo/6.0/**'
     - '.github/workflows/library-mongo6.0.yaml'
     - '!library/mongo/6.0/README.md'
+  
+  workflow_dispatch:
 
 # Automatically cancel in-progress actions on the same branch
 concurrency:

--- a/.github/workflows/library-mongo6.0.yaml
+++ b/.github/workflows/library-mongo6.0.yaml
@@ -112,7 +112,7 @@ jobs:
     - name: Install KraftKit
       run: |
         curl -sSfL https://get.kraftkit.sh | sh -s -- -y
-        echo "$HOME/.kraftkit/bin" >> $GITHUB_PATH
+        sudo mv ~/.kraftkit/bin/kraft /usr/local/bin/kraft
 
     - name: Run mongo6.0 (${{ matrix.plat }}/${{ matrix.arch }})
       env:


### PR DESCRIPTION
Added a test job to check wether the MongoDB 6.0 unikernel runs correctly on qemu.
Excluded firecracker due to a lack of port mapping compatibility.