### PR TITLE
Fix typo in Readme.md from 'querry' to 'query'

### DIFF
--- a/library/nats/2.10/Readme.md
+++ b/library/nats/2.10/Readme.md
@@ -27,7 +27,7 @@ $ nc -zv 172.44.0.2 4222
 Connection to localhost 4222 port [tcp/*] succeeded! 
 ```
 
-or querry the http server
+or query the http server
 
 ```console
 curl 172.44.0.2:8222


### PR DESCRIPTION
Fix typo in Readme.md from 'querry' to 'query'