### PR TITLE
feat(examples/hyperlight): Add async-httpserver-go1.21 example

### DIFF
--- a/examples/hyperlight/async-httpserver-go1.21/Dockerfile
+++ b/examples/hyperlight/async-httpserver-go1.21/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.21.3-bookworm AS build
+
+WORKDIR /src
+
+COPY ./server.go /src/server.go
+
+RUN set -xe; \
+    CGO_ENABLED=0 \
+    GOARCH=amd64 \
+    go build \
+      -buildmode=pie \
+      -ldflags="-linkmode=internal" \
+      -o /server server.go \
+    ;
+
+# Strip PT_INTERP from the static PIE binary: Go's internal linker adds
+# /lib64/ld-linux-x86-64.so.2 as interpreter for PIE on Linux, but the
+# binary is fully self-contained and does not need a dynamic linker.
+# Unikraft's elfloader fails when the interpreter is listed but absent.
+# Patch the program header: change PT_INTERP (type=3) -> PT_NULL (type=0).
+COPY patch_interp.py /patch_interp.py
+RUN python3 /patch_interp.py /server
+
+FROM scratch
+
+COPY --from=build /server /bin/server

--- a/examples/hyperlight/async-httpserver-go1.21/Justfile
+++ b/examples/hyperlight/async-httpserver-go1.21/Justfile
@@ -1,0 +1,47 @@
+# async go-httpserver on Hyperlight
+#
+# just run          - Run HTTP server (rootfs embedded in kernel)
+# just wrk          - wrk load test (server must be running)
+# just vegeta       - vegeta load test (server must be running)
+# just build        - Build kernel (embeds rootfs from Dockerfile)
+# just clean        - Remove build artifacts
+
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+export DOCKER_BUILDKIT := "0"
+
+kernel      := ".unikraft/build/async-httpserver-go-hyperlight-go1-21_hyperlight-x86_64"
+memory      := "128Mi"
+
+# Run HTTP server (rootfs is embedded in kernel; no --rootfs needed)
+run:
+	kraft run --plat hyperlight --rm --memory {{memory}} -p 8080:8080 {{kernel}} --as=kernel
+
+# wrk load test (server must be running)
+wrk:
+	bash bench_wrk.sh
+
+# vegeta load test (server must be running)
+vegeta:
+	bash bench_vegeta.sh
+
+# Build kernel via kraft (Linux)
+[unix]
+build:
+	kraft build --plat hyperlight --arch x86_64
+
+# Pull pre-built kernel from GHCR (Windows — no kernel published yet)
+[windows]
+build:
+	Write-Host "No pre-built kernel for async-httpserver-go yet. Build on Linux first."
+
+# Clean + rebuild everything
+rebuild: clean build
+
+# Clean build artifacts
+[unix]
+clean:
+	rm -rf .unikraft .config.*
+
+[windows]
+clean:
+	if (Test-Path .unikraft) { Remove-Item -Recurse -Force .unikraft }

--- a/examples/hyperlight/async-httpserver-go1.21/Kraftfile
+++ b/examples/hyperlight/async-httpserver-go1.21/Kraftfile
@@ -1,0 +1,92 @@
+# Go on Hyperlight - kraft configuration
+specification: '0.6'
+name: async-httpserver-go-hyperlight-go1-21
+
+unikraft:
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
+  kconfig:
+    # Platform
+    CONFIG_PLAT_HYPERLIGHT: 'y'
+    CONFIG_PAGING: 'n'
+    CONFIG_LIBUKVMEM: 'n'
+    CONFIG_LIBUKINTCTLR_HYPERLIGHT: 'y'
+    CONFIG_HYPERLIGHT_MAX_GUEST_LOG_LEVEL: 0
+
+    # Suppress kernel logging for performance
+    CONFIG_LIBUKPRINT_KLVL_CRIT: 'y'
+    CONFIG_LIBUKPRINT_PRINT_TIME: 'n'
+    CONFIG_LIBUKPRINT_PRINT_SRCNAME: 'n'
+    CONFIG_LIBUKBOOT_BANNER_NONE: 'y'
+
+    # Size optimization
+    CONFIG_OPTIMIZE_SIZE: 'y'
+    CONFIG_OPTIMIZE_PIE: 'y'
+
+    # VFS: embed rootfs in kernel at build time (no external initrd at run)
+    CONFIG_LIBVFSCORE: 'y'
+    CONFIG_LIBVFSCORE_AUTOMOUNT: 'y'
+    CONFIG_LIBVFSCORE_AUTOMOUNT_CI: 'y'
+    CONFIG_LIBVFSCORE_AUTOMOUNT_CI_EINITRD: 'y'
+    CONFIG_LIBVFSCORE_AUTOMOUNT_FB: 'y'
+    CONFIG_LIBVFSCORE_AUTOMOUNT_FB0_DEV: "embedded"
+    CONFIG_LIBVFSCORE_AUTOMOUNT_FB0_DRIVER: "extract"
+    CONFIG_LIBVFSCORE_AUTOMOUNT_FB0_MP: "/"
+    CONFIG_LIBVFSCORE_AUTOMOUNT_UP: 'y'
+    CONFIG_LIBRAMFS: 'y'
+    CONFIG_LIBUKCPIO: 'y'
+
+    # Random number support
+    CONFIG_LIBUKRANDOM_CMDLINE_SEED: 'y'
+    CONFIG_LIBUKRANDOM_GETRANDOM: 'y'
+
+    # Threading support
+    CONFIG_LIBUKBOOT_MAINTHREAD: 'y'
+    CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
+    CONFIG_LIBPOSIX_PROCESS_MULTITHREADING: 'y'
+
+    # Signal and futex support (needed for Go runtime locks)
+    CONFIG_LIBPOSIX_PROCESS_SIGNAL: 'y'
+    CONFIG_LIBPOSIX_FUTEX: 'y'
+
+    # mmap needed by Go runtime (heap reservation + page summaries)
+    CONFIG_LIBUKMPI: 'y'
+    CONFIG_LIBUKMMAP: 'y'
+
+    # devfs + /dev/hcall (required for host-proxied networking)
+    CONFIG_LIBDEVFS: 'y'
+    CONFIG_LIBDEVFS_AUTOMOUNT: 'y'
+    CONFIG_HYPERLIGHT_HCALL: 'y'
+
+    # Networking: host-proxied sockets
+    CONFIG_LIBPOSIX_SOCKET: 'y'
+    CONFIG_LIBHOSTSOCK: 'y'
+
+    # FD infrastructure (required by posix-socket)
+    CONFIG_LIBPOSIX_FDIO: 'y'
+    CONFIG_LIBPOSIX_FDTAB: 'y'
+    CONFIG_LIBUKFILE: 'y'
+
+libraries:
+  app-elfloader:
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
+    kconfig:
+      CONFIG_APPELFLOADER_VFSEXEC: 'y'
+      CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'n'
+      CONFIG_APPELFLOADER_VFSEXEC_ENVPATH: 'n'
+      CONFIG_APPELFLOADER_VFSEXEC_PATH: '/bin/server'
+      CONFIG_LIBPOSIX_ENVIRON_ENVP0: '"PATH=/bin"'
+      CONFIG_LIBPOSIX_ENVIRON_ENVP1: '"GOMEMLIMIT=128MiB"'
+      CONFIG_LIBPOSIX_ENVIRON_ENVP2: '"GOMAXPROCS=1"'
+      CONFIG_APPELFLOADER_STACK_NBPAGES: 128
+      CONFIG_LIBELF: 'y'
+  libelf:
+    source: https://github.com/unikraft/lib-libelf.git
+    version: staging
+
+targets:
+  - architecture: x86_64
+    platform: hyperlight
+
+rootfs: ./Dockerfile

--- a/examples/hyperlight/async-httpserver-go1.21/README.md
+++ b/examples/hyperlight/async-httpserver-go1.21/README.md
@@ -1,0 +1,89 @@
+# Async Go HTTP Server Example on Hyperlight
+
+This example demonstrates running an async Go 1.21 HTTP server on a Unikraft unikernel using the Hyperlight VMM driver. The server uses Go's standard `net/http` package, which handles concurrent requests with goroutines and therefore requires Hyperlight's host-proxied sockets to support `accept4(2)` (older builds return `EIO`; see [`httpserver-go1.21/server.go`](../httpserver-go1.21/server.go)). For a blocking, single-connection-at-a-time server built with raw syscalls, see [`httpserver-go1.21`](../httpserver-go1.21).
+
+## Requirements
+
+- `kraft` installed on your path.
+- `hyperlight-unikraft` VMM installed on your path.
+
+## How to Build
+
+1. Build the kernel (embeds rootfs from Dockerfile):
+   ```bash
+   just build
+   ```
+   Or manually:
+   ```bash
+   kraft build --plat hyperlight --arch x86_64
+   ```
+   *Note: The `Kraftfile` points `rootfs` at `./Dockerfile`, so KraftKit builds and embeds the rootfs during `kraft build`.*
+
+## How to Run
+
+1. Run the HTTP server:
+   ```bash
+   just run
+   ```
+   Or manually:
+   ```bash
+   kraft run --plat hyperlight --rm --memory 128Mi -p 8080:8080 .unikraft/build/async-httpserver-go-hyperlight-go1-21_hyperlight-x86_64 --as=kernel
+   ```
+
+2. Run wrk load test (server must be running):
+   ```bash
+   just wrk
+   ```
+
+3. Run vegeta load test (server must be running):
+   ```bash
+   just vegeta
+   ```
+
+Example output:
+```bash
+[i] using arch=x86_64 plat=hyperlight
+hyperlight-unikraft v0.9.0
+Kernel: ".unikraft/build/async-httpserver-go-hyperlight-go1-21_hyperlight-x86_64"
+Memory: 134217728 B, Stack: 8388608 B
+Server is running on http://localhost:8080
+[run 1/1] restore=82.4ms call=73.8ms
+[timing] evolve=149.3ms total=305.6ms
+```
+
+## Benchmarks
+
+Measured on Hyperlight with **128 MiB** guest memory, **4 wrk/vegeta threads**, and **64 concurrent connections** (wrk). All requests returned **HTTP 200**.
+
+### wrk (30s sustained load)
+
+| Endpoint | Requests | Throughput | Avg latency | Max latency |
+|----------|----------|------------|-------------|-------------|
+| `GET /` | 204,115 | **6,361 req/s** (0.90 MB/s) | 41.33 ms | 1.36 s |
+| `POST /wrk` | 192,348 | **6,006 req/s** (762 KB/s) | 42.30 ms | 1.37 s |
+
+`POST /wrk` used a 14-byte body (`hello from wrk`).
+
+### vegeta (100 req/s, 10s)
+
+| Endpoint | Requests | Success | Mean latency | p99 latency | Max latency |
+|----------|----------|---------|--------------|-------------|-------------|
+| `GET /` | 1,000 | 100% | 605 µs | 918 µs | 5.13 ms |
+| `POST /wrk` | 1,000 | 100% | 617 µs | 917 µs | 2.48 ms |
+
+`POST /wrk` used a 17-byte body (`hello from vegeta`).
+
+### Summary
+
+| Tool | Peak throughput | Sub-millisecond latency (vegeta) |
+|------|-----------------|----------------------------------|
+| wrk | ~6.4k req/s | — |
+| vegeta | 100 req/s (saturated) | ~600 µs mean, <1 ms p99 |
+
+Run the benchmarks yourself:
+
+```bash
+just run    # terminal 1
+just wrk    # terminal 2
+just vegeta # terminal 2
+```

--- a/examples/hyperlight/async-httpserver-go1.21/bench_vegeta.sh
+++ b/examples/hyperlight/async-httpserver-go1.21/bench_vegeta.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# vegeta load test for the async Go HTTP server on Hyperlight.
+# Server must already be running (just run).
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+VEGETA_RATE="${VEGETA_RATE:-100}"
+VEGETA_DURATION="${VEGETA_DURATION:-10s}"
+VEGETA_WORKERS="${VEGETA_WORKERS:-4}"
+POST_BODY="${POST_BODY:-hello from vegeta}"
+
+log() {
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+fail() {
+    log "ERROR: $*"
+    exit 1
+}
+
+command -v vegeta >/dev/null 2>&1 || fail "missing required command: vegeta (go install github.com/tsenart/vegeta/v12@latest)"
+
+run_vegeta_get() {
+    log "vegeta: GET ${BASE_URL}/"
+    log "  rate=${VEGETA_RATE}/s  duration=${VEGETA_DURATION}  workers=${VEGETA_WORKERS}"
+
+    echo "GET ${BASE_URL}/" \
+        | vegeta attack \
+            -rate "${VEGETA_RATE}" \
+            -duration "${VEGETA_DURATION}" \
+            -workers "${VEGETA_WORKERS}" \
+        | vegeta report
+}
+
+run_vegeta_post() {
+    local body_file
+    body_file="$(mktemp)"
+    trap 'rm -f "${body_file}"' RETURN
+    printf '%s' "${POST_BODY}" > "${body_file}"
+
+    log "vegeta: POST ${BASE_URL}/wrk"
+    log "  rate=${VEGETA_RATE}/s  duration=${VEGETA_DURATION}  workers=${VEGETA_WORKERS}"
+    log "  body=\"${POST_BODY}\" (${#POST_BODY} bytes)"
+
+    printf 'POST %s/wrk\nContent-Type: text/plain\n@%s\n' "${BASE_URL}" "${body_file}" \
+        | vegeta attack \
+            -rate "${VEGETA_RATE}" \
+            -duration "${VEGETA_DURATION}" \
+            -workers "${VEGETA_WORKERS}" \
+        | vegeta report
+}
+
+main() {
+    log "vegeta load test against ${BASE_URL}"
+    echo
+
+    log "=== GET / ==="
+    run_vegeta_get
+    echo
+
+    log "=== POST /wrk ==="
+    run_vegeta_post
+    echo
+
+    log "Done"
+}
+
+main "$@"

--- a/examples/hyperlight/async-httpserver-go1.21/bench_wrk.sh
+++ b/examples/hyperlight/async-httpserver-go1.21/bench_wrk.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# wrk load test for the async Go HTTP server on Hyperlight.
+# Server must already be running (just run).
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+WRK_THREADS="${WRK_THREADS:-4}"
+WRK_CONNECTIONS="${WRK_CONNECTIONS:-64}"
+WRK_DURATION="${WRK_DURATION:-30s}"
+WRK_BODY="${WRK_BODY:-hello from wrk}"
+
+log() {
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+fail() {
+    log "ERROR: $*"
+    exit 1
+}
+
+command -v wrk >/dev/null 2>&1 || fail "missing required command: wrk"
+
+run_wrk_get() {
+    log "wrk: GET ${BASE_URL}/"
+    log "  threads=${WRK_THREADS}  connections=${WRK_CONNECTIONS}  duration=${WRK_DURATION}"
+    wrk -t"${WRK_THREADS}" -c"${WRK_CONNECTIONS}" -d"${WRK_DURATION}" "${BASE_URL}/"
+}
+
+run_wrk_post() {
+    local script_file
+    script_file="$(mktemp)"
+    trap 'rm -f "${script_file}"' RETURN
+    cat > "${script_file}" <<EOF
+wrk.method = "POST"
+wrk.body = "${WRK_BODY}"
+wrk.headers["Content-Type"] = "text/plain"
+EOF
+
+    log "wrk: POST ${BASE_URL}/wrk"
+    log "  threads=${WRK_THREADS}  connections=${WRK_CONNECTIONS}  duration=${WRK_DURATION}"
+    log "  body=\"${WRK_BODY}\" (${#WRK_BODY} bytes)"
+    wrk -t"${WRK_THREADS}" -c"${WRK_CONNECTIONS}" -d"${WRK_DURATION}" -s "${script_file}" "${BASE_URL}/wrk"
+}
+
+main() {
+    log "wrk load test against ${BASE_URL}"
+    echo
+
+    log "=== GET / ==="
+    run_wrk_get
+    echo
+
+    log "=== POST /wrk ==="
+    run_wrk_post
+    echo
+
+    log "Done"
+}
+
+main "$@"

--- a/examples/hyperlight/async-httpserver-go1.21/patch_interp.py
+++ b/examples/hyperlight/async-httpserver-go1.21/patch_interp.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Strip PT_INTERP from a static PIE binary.
+
+Go's internal linker adds /lib64/ld-linux-x86-64.so.2 as PT_INTERP for PIE
+binaries on Linux, but a CGO_ENABLED=0 binary is fully self-contained and
+does not need a dynamic linker. Patch PT_INTERP -> PT_NULL so elfloaders
+that reject missing interpreters will load the binary directly.
+"""
+import struct
+import sys
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} <path-to-elf>", file=sys.stderr)
+    sys.exit(2)
+
+path = sys.argv[1]
+with open(path, "rb") as f:
+    data = bytearray(f.read())
+
+if len(data) < 64 or data[:4] != b"\x7fELF" or data[4] != 2 or data[5] != 1:
+    raise SystemExit("unsupported input: expected ELF64 little-endian")
+
+e_phoff,     = struct.unpack_from("<Q", data, 32)
+e_phentsize, = struct.unpack_from("<H", data, 54)
+e_phnum,     = struct.unpack_from("<H", data, 56)
+
+for i in range(e_phnum):
+    off = e_phoff + i * e_phentsize
+    p_type, = struct.unpack_from("<I", data, off)
+    if p_type == 3:  # PT_INTERP
+        struct.pack_into("<I", data, off, 0)  # PT_NULL
+        print(f"Patched PT_INTERP -> PT_NULL at program header index {i}")
+
+with open(path, "wb") as f:
+    f.write(data)
+

--- a/examples/hyperlight/async-httpserver-go1.21/server.go
+++ b/examples/hyperlight/async-httpserver-go1.21/server.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+func helloHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "Hello from Hyperlight-Unikraft!")
+}
+
+func wrkHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	bodyLen := int(r.ContentLength)
+	if bodyLen < 0 {
+		bodyLen = 0
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, "{\"received_bytes\":%d}\n", bodyLen)
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", helloHandler)
+	mux.HandleFunc("/wrk", wrkHandler)
+
+	server := &http.Server{
+		Addr:              ":8080",
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	fmt.Println("Server is running on http://localhost:8080")
+	log.Fatal(server.ListenAndServe())
+}


### PR DESCRIPTION
Add an async Go 1.21 HTTP server on Hyperlight using net/http with goroutine-based concurrency, embedded rootfs, and wrk/vegeta benchmark scripts.