### PR TITLE
feat(examples): Add Traefik example

### DIFF
--- a/examples/traefik3.0-20-alpine3.23-base/.dockerignore
+++ b/examples/traefik3.0-20-alpine3.23-base/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/traefik3.0-20-alpine3.23-base/.gitignore
+++ b/examples/traefik3.0-20-alpine3.23-base/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/traefik3.0-20-alpine3.23-base/Dockerfile
+++ b/examples/traefik3.0-20-alpine3.23-base/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:20-alpine3.23 AS builder
+
+WORKDIR /traefik-src
+
+RUN apk add --no-cache git gcc musl-dev ca-certificates go
+
+RUN git clone --depth 1 -b v3.0.0 https://github.com/traefik/traefik.git .
+
+RUN cd webui && yarn install && yarn build
+
+RUN CGO_ENABLED=0 go build -buildmode=pie -ldflags '-s -w' -o /traefik-binary ./cmd/traefik
+
+FROM scratch
+
+COPY --from=builder /traefik-binary /usr/local/bin/traefik
+
+COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+
+COPY dynamic.yml /etc/traefik/dynamic.yml
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+ENTRYPOINT ["/usr/local/bin/traefik"]

--- a/examples/traefik3.0-20-alpine3.23-base/Kraftfile
+++ b/examples/traefik3.0-20-alpine3.23-base/Kraftfile
@@ -1,0 +1,17 @@
+spec: v0.6
+
+name: traefik
+
+runtime: unikraft.org/base:latest
+
+rootfs: ./Dockerfile
+
+ports:
+  - "8080:80"
+  - "8081:8080"
+
+cmd: 
+  - "/usr/local/bin/traefik"
+  - "--api.insecure=true"
+  - "--providers.file.filename=/etc/traefik/dynamic.yml"
+  - "--providers.file.watch=false"

--- a/examples/traefik3.0-20-alpine3.23-base/README.md
+++ b/examples/traefik3.0-20-alpine3.23-base/README.md
@@ -1,0 +1,81 @@
+# Traefik 3.0 Proxy on Unikraft
+
+This directory contains an example [Traefik 3.0](https://doc.traefik.io/traefik/) Proxy.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Prerequisites
+
+To use this example, it is recommended to create an instance of `traefik/whoami` in a Docker container to see the effects of the app in practice.
+
+Use the commands below to pull the image of `traefik/whoami` and run it in a container.
+
+```bash
+docker pull traefik/whoami
+docker run -d -p 8000:80 --name whoami traefik/whoami
+```
+
+Note: `dynamic.yml` is configured to reach the `whoami` container via the Docker bridge IP (`http://172.17.0.1:8000`). If your bridge IP differs (or you’re on a non-Linux Docker setup), update `dynamic.yml` accordingly. You can verify your local Docker bridge IP by using the following command:
+
+```bash
+docker network inspect bridge -f '{{(index .IPAM.Config 0).Gateway}}'
+```
+
+## Run and Use
+
+Warning: This example enables the insecure Traefik API/dashboard (`--api.insecure=true`). Do not expose the dashboard port (8081) to untrusted networks.
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -M 1G -p 8080:80 -p 8081:8080
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open ports `8080` and `8081` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8081/dashboard
+curl -H 'Host: whoami.localhost' http://localhost:8080 # the service that Traefik exposes (in this example a whoami server written in Go)
+```
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME                      KERNEL                                 ARGS                                                  CREATED         STATUS   MEM   ...
+agitated_frodo            oci://unikraft.org/base:latest         /usr/local/bin/traefik --api.insecure=true --prov...  12 minutes ago  running  976M  ...
+```
+
+The instance name is `agitated_frodo`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm agitated_frodo
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -M 2G -p 8080:80 -p 8081:8080
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/traefik3.0-20-alpine3.23-base/dynamic.yml
+++ b/examples/traefik3.0-20-alpine3.23-base/dynamic.yml
@@ -1,0 +1,12 @@
+http:
+  routers:
+    
+    whoami-router:
+      rule: "Host(`whoami.localhost`)"
+      service: "whoami-service"
+  
+  services:
+    whoami-service:
+      loadBalancer:
+        servers:
+          - url: "http://172.17.0.1:8000"


### PR DESCRIPTION
Added a binary compatibility port for Traefik v3.0.0 using the `base:latest` runtime.

**Implementation Details:**
- **Build/Rootfs:** Implemented a multi-stage `Dockerfile` to fetch the Traefik sources, compile them, and copy the required `/lib` directory directly into the rootfs.
- **Syscall Debugging & Workaround:** During testing, the `app-elfloader` crashed at `vfs` initialization due to missing `inotify` syscalls required by Traefik's file watcher. Bypassed this unsupported Unikraft feature by passing `--providers.file.watch=false` to the startup command in the Kraftfile.
- **Network:** Validated routing to an external Docker container which has port `8000` exposed using Docker bridge IP (configured in `dynamic.yml`: `172.17.0.1:8000`).