### PR TITLE
feat: Add hyperlight examples using base runtime

### DIFF
--- a/examples/hyperlight/helloworld-zig0.11/Dockerfile
+++ b/examples/hyperlight/helloworld-zig0.11/Dockerfile
@@ -1,0 +1,33 @@
+FROM gcc:13.2.0-bookworm AS zig
+
+RUN set -xe; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      xz-utils;
+
+WORKDIR /zig
+
+ARG ZIG_VERSION=0.11.0
+
+RUN set -xe; \
+    curl -o /zig.tar.xz https://ziglang.org/download/${ZIG_VERSION}/zig-linux-$(uname -m)-${ZIG_VERSION}.tar.xz; \
+    tar -xf /zig.tar.xz --strip-components 1 -C /zig; \
+    mv /zig/zig /usr/bin/zig; \
+    mv /zig/lib /usr/lib/zig
+
+FROM zig AS build
+
+WORKDIR /src
+
+COPY . /src
+
+RUN set -xe; \
+    zig build-exe /src/helloworld.zig -fPIE -target x86_64-linux-gnu
+
+FROM scratch
+
+COPY --from=build /src/helloworld /helloworld
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/

--- a/examples/hyperlight/helloworld-zig0.11/Justfile
+++ b/examples/hyperlight/helloworld-zig0.11/Justfile
@@ -1,0 +1,21 @@
+# helloworld-zig0.11 on Hyperlight
+#
+# just build        - Build rootfs via kraft build
+# just run          - Run application (uses Hyperlight runtime)
+# just clean        - Remove build artifacts
+
+initrd := ".unikraft/build/initramfs-x86_64.cpio"
+memory := "64Mi"
+
+# Build rootfs via kraft
+build:
+	kraft build --rootfs ./Dockerfile --plat hyperlight --arch x86_64
+
+# Run application with Kraft
+run:
+	kraft run --plat hyperlight --rm --memory {{memory}} --rootfs {{initrd}} .
+
+# Clean build artifacts
+[unix]
+clean:
+	rm -rf .unikraft .config.*

--- a/examples/hyperlight/helloworld-zig0.11/Kraftfile
+++ b/examples/hyperlight/helloworld-zig0.11/Kraftfile
@@ -1,0 +1,13 @@
+spec: v0.6
+
+name: helloworld-zig0.11-hyperlight
+
+runtime: base:latest
+
+targets:
+  - platform: hyperlight
+    architecture: x86_64
+
+rootfs: .unikraft/build/initramfs-x86_64.cpio
+
+cmd: ["/helloworld"]

--- a/examples/hyperlight/helloworld-zig0.11/README.md
+++ b/examples/hyperlight/helloworld-zig0.11/README.md
@@ -1,0 +1,40 @@
+# Zig 0.11 Hello World on Hyperlight (Base Runtime)
+
+This directory contains a Zig 0.11 Hello World example running on Unikraft using the Hyperlight VMM driver and base runtime (`base:latest`).
+
+## Requirements
+
+- `kraft` installed on your path.
+- `hyperlight-unikraft` VMM installed on your path.
+
+## How to Build and Run
+
+1. Build the rootfs:
+
+```bash
+kraft build --rootfs ./Dockerfile --plat hyperlight --arch x86_64
+```
+
+Or using `just`:
+
+```bash
+just build
+```
+
+2. Run using `kraft`:
+
+```bash
+kraft run --plat hyperlight --rootfs .unikraft/build/initramfs-x86_64.cpio .
+```
+
+Or using `just`:
+
+```bash
+just run
+```
+
+You should see output:
+
+```
+Hello from Zig on Hyperlight!
+```

--- a/examples/hyperlight/helloworld-zig0.11/helloworld.zig
+++ b/examples/hyperlight/helloworld-zig0.11/helloworld.zig
@@ -1,0 +1,5 @@
+const std = @import("std");
+
+pub fn main() !void {
+    std.debug.print("Hello from Zig on Hyperlight!\n", .{});
+}

--- a/examples/hyperlight/httpserver-gcc13.2/Dockerfile
+++ b/examples/hyperlight/httpserver-gcc13.2/Dockerfile
@@ -1,0 +1,17 @@
+FROM gcc:13.2.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./http_server.c /src/http_server.c
+
+RUN set -xe; \
+    gcc \
+	-Wall -Wextra \
+	-fPIC -pie \
+	-o /http_server http_server.c
+
+FROM scratch
+
+COPY --from=build /http_server /http_server
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/

--- a/examples/hyperlight/httpserver-gcc13.2/Justfile
+++ b/examples/hyperlight/httpserver-gcc13.2/Justfile
@@ -1,0 +1,21 @@
+# httpserver-gcc13.2 on Hyperlight
+#
+# just build        - Build rootfs via kraft build
+# just run          - Run HTTP server (uses Hyperlight runtime)
+# just clean        - Remove build artifacts
+
+initrd := ".unikraft/build/initramfs-x86_64.cpio"
+memory := "64Mi"
+
+# Build rootfs via kraft
+build:
+	kraft build --rootfs ./Dockerfile --plat hyperlight --arch x86_64
+
+# Run HTTP server with Kraft
+run:
+	kraft run --plat hyperlight --rm --memory {{memory}} --rootfs {{initrd}} -p 8080:8080 .
+
+# Clean build artifacts
+[unix]
+clean:
+	rm -rf .unikraft .config.*

--- a/examples/hyperlight/httpserver-gcc13.2/Kraftfile
+++ b/examples/hyperlight/httpserver-gcc13.2/Kraftfile
@@ -1,0 +1,13 @@
+spec: v0.6
+
+name: httpserver-gcc13.2-hyperlight
+
+runtime: base:latest
+
+targets:
+  - platform: hyperlight
+    architecture: x86_64
+
+rootfs: .unikraft/build/initramfs-x86_64.cpio
+
+cmd: ["/http_server"]

--- a/examples/hyperlight/httpserver-gcc13.2/README.md
+++ b/examples/hyperlight/httpserver-gcc13.2/README.md
@@ -1,0 +1,46 @@
+# C HTTP Server on Hyperlight (Base Runtime)
+
+This directory contains a C-based HTTP server example running on Unikraft using the Hyperlight VMM driver and base runtime (`base:latest`).
+
+## Requirements
+
+- `kraft` installed on your path.
+- `hyperlight-unikraft` VMM installed on your path.
+
+## How to Build and Run
+
+1. Build the rootfs:
+
+```bash
+kraft build --rootfs ./Dockerfile --plat hyperlight --arch x86_64
+```
+
+Or using `just`:
+
+```bash
+just build
+```
+
+2. Run the HTTP server using `kraft`:
+
+```bash
+kraft run --plat hyperlight --rootfs .unikraft/build/initramfs-x86_64.cpio -p 8080:8080 .
+```
+
+Or using `just`:
+
+```bash
+just run
+```
+
+Once executed, port `8080` will be open. You can test it with `curl`:
+
+```bash
+curl http://localhost:8080
+```
+
+You should see:
+
+```html
+<html><body><h1>Hello from Hyperlight!</h1></body></html>
+```

--- a/examples/hyperlight/httpserver-gcc13.2/http_server.c
+++ b/examples/hyperlight/httpserver-gcc13.2/http_server.c
@@ -1,0 +1,91 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2024, Unikraft GmbH and the Unikraft Authors.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <errno.h>
+
+#define LISTEN_PORT 8080
+#define BUFLEN 2048
+
+static const char reply[] = "HTTP/1.1 200 OK\r\n"
+			    "Content-Type: text/html; charset=utf-8\r\n"
+			    "Content-Length: 55\r\n"
+			    "Connection: close\r\n"
+			    "\r\n"
+			    "<html><body><h1>Hello from Hyperlight!</h1></body></html>\n";
+
+static const char not_found[] = "HTTP/1.1 404 Not Found\r\n"
+				"Content-Type: text/plain\r\n"
+				"Content-Length: 10\r\n"
+				"Connection: close\r\n"
+				"\r\n"
+				"Not Found\n";
+
+static char recvbuf[BUFLEN];
+
+int main(int argc __attribute__((unused)),
+	 char *argv[] __attribute__((unused)))
+{
+	int rc = 0;
+	int srv, client;
+	ssize_t n;
+	struct sockaddr_in srv_addr;
+
+	srv = socket(AF_INET, SOCK_STREAM, 0);
+	if (srv < 0) {
+		fprintf(stderr, "Failed to create socket: %d\n", errno);
+		return 1;
+	}
+
+	int optval = 1;
+	setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+
+	srv_addr.sin_family = AF_INET;
+	srv_addr.sin_addr.s_addr = INADDR_ANY;
+	srv_addr.sin_port = htons(LISTEN_PORT);
+
+	rc = bind(srv, (struct sockaddr *) &srv_addr, sizeof(srv_addr));
+	if (rc < 0) {
+		fprintf(stderr, "Failed to bind socket: %d\n", errno);
+		close(srv);
+		return 1;
+	}
+
+	rc = listen(srv, 128);
+	if (rc < 0) {
+		fprintf(stderr, "Failed to listen on socket: %d\n", errno);
+		close(srv);
+		return 1;
+	}
+
+	printf("Serving on http://0.0.0.0:%d...\n", LISTEN_PORT);
+	while (1) {
+		client = accept(srv, NULL, 0);
+		if (client < 0) {
+			fprintf(stderr, "Failed to accept incoming connection: %d\n", errno);
+			continue;
+		}
+
+		memset(recvbuf, 0, BUFLEN);
+		n = read(client, recvbuf, BUFLEN - 1);
+		if (n > 0) {
+			/* Handle GET request */
+			if (strncmp(recvbuf, "GET", 3) == 0) {
+				write(client, reply, strlen(reply));
+			} else {
+				write(client, not_found, strlen(not_found));
+			}
+		}
+
+		close(client);
+	}
+
+	close(srv);
+	return 0;
+}

--- a/examples/hyperlight/httpserver-rust1.75/Dockerfile
+++ b/examples/hyperlight/httpserver-rust1.75/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:1.75.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./server.rs /src/server.rs
+
+RUN set -xe; \
+    rustc -C relocation-model=pie -o /server /src/server.rs
+
+FROM scratch
+
+COPY --from=build /server /server
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/

--- a/examples/hyperlight/httpserver-rust1.75/Justfile
+++ b/examples/hyperlight/httpserver-rust1.75/Justfile
@@ -1,0 +1,25 @@
+# httpserver-rust1.75-base on Hyperlight
+#
+# just build        - Build rootfs via kraft build
+# just run          - Run HTTP server (uses Hyperlight runtime)
+# just clean        - Remove build artifacts
+
+initrd := ".unikraft/build/initramfs-x86_64.cpio"
+memory := "64Mi"
+
+# Build rootfs via kraft
+build:
+	kraft build --rootfs ./Dockerfile --plat hyperlight --arch x86_64
+
+# Run HTTP server with Kraft
+run:
+	kraft run --plat hyperlight --rm --memory {{memory}} --rootfs {{initrd}} -p 8080:8080 .
+
+# Clean build artifacts
+[unix]
+clean:
+	rm -rf .unikraft .config.*
+
+[windows]
+clean:
+	if (Test-Path .unikraft) { Remove-Item -Recurse -Force .unikraft }

--- a/examples/hyperlight/httpserver-rust1.75/Kraftfile
+++ b/examples/hyperlight/httpserver-rust1.75/Kraftfile
@@ -1,0 +1,13 @@
+spec: v0.6
+
+name: httpserver-rust1.75-base-hyperlight
+
+runtime: base:latest
+
+targets:
+  - platform: hyperlight
+    architecture: x86_64
+
+rootfs: .unikraft/build/initramfs-x86_64.cpio
+
+cmd: ["/server"]

--- a/examples/hyperlight/httpserver-rust1.75/README.md
+++ b/examples/hyperlight/httpserver-rust1.75/README.md
@@ -1,0 +1,46 @@
+# Rust 1.75 HTTP Server on Hyperlight (Base Runtime)
+
+This directory contains a Rust 1.75 HTTP server example running on Unikraft using the Hyperlight VMM driver and base runtime (`base:latest`).
+
+## Requirements
+
+- `kraft` installed on your path.
+- `hyperlight-unikraft` VMM installed on your path.
+
+## How to Build and Run
+
+1. Build the rootfs:
+
+```bash
+kraft build --rootfs ./Dockerfile --plat hyperlight --arch x86_64
+```
+
+Or using `just`:
+
+```bash
+just build
+```
+
+2. Run the HTTP server using `kraft`:
+
+```bash
+kraft run --plat hyperlight --rootfs .unikraft/build/initramfs-x86_64.cpio -p 8080:8080 .
+```
+
+Or using `just`:
+
+```bash
+just run
+```
+
+Once executed, port `8080` will be open. You can test it with `curl`:
+
+```bash
+curl http://localhost:8080
+```
+
+You should see:
+
+```html
+<html><body><h1>Hello from Rust on Hyperlight!</h1></body></html>
+```

--- a/examples/hyperlight/httpserver-rust1.75/server.rs
+++ b/examples/hyperlight/httpserver-rust1.75/server.rs
@@ -1,0 +1,49 @@
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+
+fn handle_client(mut stream: TcpStream) {
+    let mut buf = [0u8; 2048];
+    if let Ok(n) = stream.read(&mut buf) {
+        if n > 0 {
+            let req_str = String::from_utf8_lossy(&buf[..n]);
+            if req_str.starts_with("GET") {
+                let response = b"HTTP/1.1 200 OK\r\n\
+                                Content-Type: text/html; charset=utf-8\r\n\
+                                Content-Length: 56\r\n\
+                                Connection: close\r\n\r\n\
+                                <html><body><h1>Hello from Rust on Hyperlight!</h1></body></html>\n";
+                let _ = stream.write_all(response);
+            } else {
+                let not_found = b"HTTP/1.1 404 Not Found\r\n\
+                                  Content-Type: text/plain\r\n\
+                                  Content-Length: 10\r\n\
+                                  Connection: close\r\n\r\n\
+                                  Not Found\n";
+                let _ = stream.write_all(not_found);
+            }
+        }
+    }
+}
+
+fn main() {
+    let listener = match TcpListener::bind("0.0.0.0:8080") {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("Failed to bind socket: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    println!("Serving on http://0.0.0.0:8080...");
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                handle_client(stream);
+            }
+            Err(e) => {
+                eprintln!("Accept failed: {}", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# feat(examples/hyperlight): Add Hyperlight base runtime examples

This PR adds 3 new Hyperlight runtime examples using the `base:latest` base runtime (`library/base-hyperlight`).

## Changes Included

- `examples/hyperlight/httpserver-gcc13.2`: C HTTP server running on Hyperlight base runtime on port 8080.
- `examples/hyperlight/httpserver-rust1.75`: Rust HTTP server running on Hyperlight base runtime on port 8080.
- `examples/hyperlight/helloworld-zig0.11`: Zig 0.11 Hello World example running on Hyperlight base runtime.

## Verification

Each example was verified using `kraft build` and `kraft run --plat hyperlight`:
- `httpserver-gcc13.2`: Verified HTTP GET response via `curl http://localhost:8080`.
- `httpserver-rust1.75`: Verified HTTP GET response via `curl http://localhost:8080`.
- `helloworld-zig0.11`: Verified stdout execution (`Hello from Zig on Hyperlight!`).
