### PR TITLE
feat(examples): Add helloworld-rust1.75-distroless example

### DIFF
--- a/.github/workflows/test-helloworld-rust-distroless.yml
+++ b/.github/workflows/test-helloworld-rust-distroless.yml
@@ -1,0 +1,96 @@
+name: Test Rust Helloworld Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/helloworld-rust1.75-distroless/**"
+      - ".github/workflows/test-helloworld-rust-distroless.yml"
+  pull_request:
+    paths:
+      - "examples/helloworld-rust1.75-distroless/**"
+      - ".github/workflows/test-helloworld-rust-distroless.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Install KraftKit (Version Pinned & Verified)
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+
+          grep " kraft_${KRAFT_VERSION}_linux_amd64.tar.gz\$" "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/helloworld-rust1.75-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/helloworld-rust1.75-distroless
+        run: |
+          set -euo pipefail
+
+          mapfile -t cpio_files < <(find .unikraft/build/ -type f -name "*.cpio")
+          if [ "${#cpio_files[@]}" -eq 0 ]; then
+            echo "No .cpio artifacts found under .unikraft/build/" >&2
+            exit 1
+           fi
+
+           du -h "${cpio_files[@]}"
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/helloworld-rust1.75-distroless
+        run: docker build --pull -t helloworld-rust1.75-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          scan-ref: "helloworld-rust1.75-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/helloworld-rust1.75-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run and Validate Output
+        working-directory: examples/helloworld-rust1.75-distroless
+        run: |
+          set -euo pipefail
+          kraft run --rm --plat qemu --arch x86_64 -M 128M . | tee run-output.log
+          grep -q "Bye, world, from rust" run-output.log

--- a/examples/helloworld-rust1.75-distroless/.trivyignore
+++ b/examples/helloworld-rust1.75-distroless/.trivyignore
@@ -1,0 +1,4 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30
+

--- a/examples/helloworld-rust1.75-distroless/Dockerfile
+++ b/examples/helloworld-rust1.75-distroless/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.75.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./helloworld.rs /src/helloworld.rs
+
+RUN set -xe; \
+    rustc -o /helloworld /src/helloworld.rs
+
+FROM gcr.io/distroless/cc-debian12@sha256:e5d81ddde149641e2a9ba55be4545bc125c67de07508b03ba4c22e6eb0ded5aa
+
+COPY --from=build /helloworld /helloworld
+

--- a/examples/helloworld-rust1.75-distroless/Kraftfile
+++ b/examples/helloworld-rust1.75-distroless/Kraftfile
@@ -1,0 +1,10 @@
+spec: v0.6
+
+name: helloworld-rust1.75-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/helloworld"]
+

--- a/examples/helloworld-rust1.75-distroless/README.md
+++ b/examples/helloworld-rust1.75-distroless/README.md
@@ -1,0 +1,65 @@
+# Rust "Hello, World! - Distroless"
+
+This directory contains a [Rust](https://www.rust-lang.org/) "Hello, World!" example running on Unikraft.
+It utilizes a Distroless container image to provide a minimal, secure root filesystem containing only the required runtime dependencies.
+
+## Distroless Build
+
+For this example's needs, the chosen distroless image provides:
+
+- The dynamic linker `ld-linux-x86-64`
+- The libraries `libc` and `libgcc_s`
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm --plat qemu --arch x86_64 -M 128M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+You should see a "Bye, world, from rust 🦀!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME            KERNEL                          ARGS         CREATED        STATUS   MEM  PORTS  PLAT
+juicy_goblin  oci://unikraft.org/base:latest  /helloworld  9 seconds ago  running  128M         qemu/x86_64
+```
+
+The instance name is `juicy_goblin`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm juicy_goblin
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm --plat qemu --arch x86_64 -M 512M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/helloworld-rust1.75-distroless/helloworld.rs
+++ b/examples/helloworld-rust1.75-distroless/helloworld.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("Bye, world, from rust 🦀!");
+}
+


### PR DESCRIPTION
## Description

Added a Rust helloworld example using the distroless container image `gcr.io/distroless/cc-debian12`, which is compatible with `bookworm` and provides sufficient dependencies. This example is based on the [existing one](https://github.com/unikraft/catalog/tree/main/examples/helloworld-rust1.75) in the catalog, enhancing the container build via distroless.

The `README.md` file contains instructions for building and running the example manually.

## Automated Testing

The second commit of this PR contains a three-stage workflow to build and test this example via Github Actions:

1. Measuring the `rootfs` size (resulting in *28MB*)
2. Scanning for vulnerabilities using Trivy (one found, but not relevant, see `.trivyignore` for more)
3. Validating the output using `grep`