### PR TITLE
feat(examples): Add helloworld-gcc15.2-distroless example

### DIFF
--- a/.github/workflows/test-helloworld-gcc15.2-distroless.yaml
+++ b/.github/workflows/test-helloworld-gcc15.2-distroless.yaml
@@ -1,0 +1,82 @@
+name: Test C Helloworld Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/helloworld-gcc15.2-distroless/**"
+      - ".github/workflows/test-helloworld-gcc15.2-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/helloworld-gcc15.2-distroless/**"
+      - ".github/workflows/test-helloworld-gcc15.2-distroless.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit (Version Pinned & Verified)
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+
+          awk -v f="kraft_${KRAFT_VERSION}_linux_amd64.tar.gz" '($2==f)||($2=="*"f){print}' "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/helloworld-gcc15.2-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/helloworld-gcc15.2-distroless
+        run: |
+          du -sh .unikraft/build/initramfs-x86_64.cpio
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/helloworld-gcc15.2-distroless
+        run: docker build --pull -t helloworld-gcc15.2-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          image-ref: "helloworld-gcc15.2-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/helloworld-gcc15.2-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run and Validate Output
+        working-directory: examples/helloworld-gcc15.2-distroless
+        run: |
+           set -euo pipefail
+           kraft run --rm --plat qemu --arch x86_64 -M 128M . | grep "Hello, World!"

--- a/examples/helloworld-gcc15.2-distroless/.trivyignore
+++ b/examples/helloworld-gcc15.2-distroless/.trivyignore
@@ -1,0 +1,3 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30

--- a/examples/helloworld-gcc15.2-distroless/Dockerfile
+++ b/examples/helloworld-gcc15.2-distroless/Dockerfile
@@ -1,0 +1,15 @@
+FROM gcc:15.2.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./helloworld.c /src/helloworld.c
+
+RUN set -xe; \
+  gcc \
+  -Wall -Wextra \
+  -fPIC -pie \
+  -o /helloworld helloworld.c
+
+FROM gcr.io/distroless/cc-debian12@sha256:e5d81ddde149641e2a9ba55be4545bc125c67de07508b03ba4c22e6eb0ded5aa
+
+COPY --from=build /helloworld /helloworld

--- a/examples/helloworld-gcc15.2-distroless/Kraftfile
+++ b/examples/helloworld-gcc15.2-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: helloworld-gcc15.2-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/helloworld"]

--- a/examples/helloworld-gcc15.2-distroless/README.md
+++ b/examples/helloworld-gcc15.2-distroless/README.md
@@ -1,0 +1,56 @@
+# C "Hello, World!" - Distroless
+
+This directory contains a C-based "Hello, World!" example running on Unikraft using the gcr.io/distroless/cc-debian12 base image. This minimal environment lacks a shell and unnecessary system utilities, significantly reducing the attack surface.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm --plat qemu --arch x86_64 -M 128M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+If the `-M` argument (memory allocation) is left out, it defaults to 64M. For this specific image,
+leaving it out will cause a boot failure (cpio archive extraction error) because the virtual machine
+runs out of memory while unpacking the filesystem in RAM. Explicitly setting it to -M 128M
+provides enough memory and ensures the unikernel boots successfully.
+
+Once executed, you should see a "Hello, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME              KERNEL                          ARGS         CREATED  STATUS   MEM   PORTS  PLAT
+festive_albertii  oci://unikraft.org/base:latest  /helloworld  now      running  122M         qemu/x86_64
+```
+
+The instance name is `festive_albertii`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm festive_albertii
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/helloworld-gcc15.2-distroless/helloworld.c
+++ b/examples/helloworld-gcc15.2-distroless/helloworld.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main(void)
+{
+	puts("Hello, World!");
+
+	return 0;
+}


### PR DESCRIPTION
## Description

Added a C helloworld example using the distroless container image `cc-debian12`, which provides a minimal environment with sufficient dependencies. This example is based on the existing one in the catalog, enhancing the container build via distroless.

The `README.md` file contains instructions for building and running the example manually.

## Automated Testing

The second commit of this PR contains a three-stage workflow to build and test this example via GitHub Actions:

1. Measuring the `rootfs` size (resulting in 23MB)
2. Scanning for vulnerabilities using Trivy
3. Validating the output using `grep`

### Note on Vulnerability Scanning:
Trivy scans are configured to pass by explicitly ignoring CVE-2026-14456 (libssl3) via .trivyignore. This vulnerability affects OpenSSL QUIC servers, a feature that this simple application does not implement or utilize. Furthermore, there is currently no official upstream fix available for the base image. This exception and the non-clean base state are explicitly acknowledged here.