### PR TITLE
feat(examples): Add helloworld-g++13.2-distroless example

### DIFF
--- a/.github/workflows/test-helloworld-g++13.2-distroless.yaml
+++ b/.github/workflows/test-helloworld-g++13.2-distroless.yaml
@@ -1,0 +1,47 @@
+name: Test C++13.2 Helloworld Distroless
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        run: curl -sSfL https://get.kraftkit.sh | sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Build Unikernel
+        working-directory: examples/helloworld-g++13.2-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/helloworld-g++13.2-distroless
+        run: |
+          du -sh .unikraft/build/ || true
+          find .unikraft/build/ -type f -name "*.img" -exec du -h {} + || true
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          scan-ref: "examples/helloworld-g++13.2-distroless"
+          format: "table"
+          exit-code: "0"
+          severity: "CRITICAL,HIGH"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          sudo chmod 666 /dev/kvm
+
+      - name: Run and Validate Output
+        working-directory: examples/helloworld-g++13.2-distroless
+        run: |
+          kraft run --rm -M 128M

--- a/examples/helloworld-g++13.2-distroless/Dockerfile
+++ b/examples/helloworld-g++13.2-distroless/Dockerfile
@@ -1,0 +1,15 @@
+FROM gcc:13.2.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./helloworld.cpp /src/helloworld.cpp
+
+RUN set -xe; \
+    g++ \
+    -Wall -Wextra \
+    -fPIC -pie \
+    -o /helloworld helloworld.cpp
+
+FROM gcr.io/distroless/cc-debian13
+
+COPY --from=build /helloworld /helloworld

--- a/examples/helloworld-g++13.2-distroless/Kraftfile
+++ b/examples/helloworld-g++13.2-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: helloworld-g++13.2-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/helloworld"]

--- a/examples/helloworld-g++13.2-distroless/README.md
+++ b/examples/helloworld-g++13.2-distroless/README.md
@@ -1,0 +1,95 @@
+# C++ "Hello, World!" - GCC 13.2 Distroless
+
+This directory contains a C++-based "Hello, World!" example running on Unikraft with a Distroless runtime environment.
+
+The example uses GCC 13.2 to compile the application and packages the resulting executable using the `gcr.io/distroless/cc-debian12` runtime image.
+
+## Set Up
+
+To run this example, install Unikraft's companion command-line toolchain `kraft`, clone this repository and change into this directory.
+
+You also need Docker, which is used by KraftKit to build the root filesystem from the Dockerfile.
+
+## Run and Use
+
+Use `kraft` to build the root filesystem and start a Unikraft instance:
+
+```bash
+kraft run --rm --plat qemu --arch x86_64 -M 128M .
+```
+
+The --plat qemu argument selects QEMU as the platform, while --arch x86_64 selects the x86_64 architecture.
+
+The -M 128M option allocates 128 MB of memory to the Unikraft instance.
+
+Once the instance starts successfully, the following output should be displayed:
+
+```bash
+Bye, World!
+```
+
+Distroless Runtime
+
+Unlike a traditional Linux distribution, the runtime image used by this example is based on the Distroless C++ image:
+
+```bash
+gcr.io/distroless/cc-debian12
+```
+
+The Distroless runtime does not include a shell, package manager, or other general-purpose command-line utilities. It contains the runtime libraries required by the application without the additional tools normally found in a general-purpose Linux distribution.
+
+The Dockerfile uses two stages:
+
+A gcc:13.2.0-bookworm builder stage compiles helloworld.cpp.
+The resulting /helloworld executable is copied into the Distroless C++ runtime image.
+
+The resulting filesystem is then used as the root filesystem of the Unikraft unikernel.
+
+## Verify the Application with Docker
+
+The Distroless image can also be built and tested independently from Unikraft:
+
+```bash
+docker build -t helloworld-g13-distroless .
+```
+
+
+## Run the application directly from the Distroless image:
+
+```bash
+docker run --rm helloworld-g13-distroless
+```
+
+The expected output is:
+
+```bash
+Bye, World!
+```
+
+The Distroless image intentionally does not provide an interactive shell. For example, attempting to start /bin/sh is expected to fail because the shell is not included in the image.
+
+## Inspect and Close
+
+To list running Unikraft instances, use:
+
+```bash
+kraft ps
+```
+
+If the instance was not started with --rm, it can be stopped and removed with:
+```bash
+kraft rm <instance-name>
+```
+When kraft run is executed with --rm, the instance is automatically removed after it exits.
+
+## kraft and sudo
+
+Mixing invocations of kraft and sudo can lead to unexpected behavior.
+
+Read more about how to start kraft without sudo at:
+
+https://unikraft.org/sudoless
+
+## Learn More
+https://unikraft.org/docs/cli/running
+https://unikraft.org/guides/building-dockerfile-images-with-buildkit

--- a/examples/helloworld-g++13.2-distroless/helloworld.cpp
+++ b/examples/helloworld-g++13.2-distroless/helloworld.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+int main()
+{
+	std::cout << "Bye, World!" << std::endl;
+
+	return 0;
+}


### PR DESCRIPTION
## Description

Added a C++ Hello World example using GCC 13.2.0 and the distroless container image `cc-debian13`, which provides a minimal runtime environment with the dependencies required by the application. This example is based on the existing C++ 13.2 Hello World example in the catalog, adapting the container build to use a distroless runtime.

The `README.md` file contains instructions for building and running the example manually.

## Automated Testing

The second commit of this PR contains a three-stage workflow to build and test this example via GitHub Actions:

1. Measuring the `rootfs` size
2. Scanning for vulnerabilities using Trivy
3. Validating the application output using `grep`

---
The workflow also installs QEMU and grants access to `/dev/kvm` before running the unikernel.
