### PR TITLE
feat(examples): Add helloworld-gcc13.2-distroless example

### DIFF
--- a/.github/workflows/test-helloworld-gcc13.2-distroless.yaml
+++ b/.github/workflows/test-helloworld-gcc13.2-distroless.yaml
@@ -1,0 +1,47 @@
+name: Test C GCC 13.2 Helloworld Distroless
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        run: curl -sSfL https://get.kraftkit.sh | sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Build Unikernel
+        working-directory: examples/helloworld-gcc13.2-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/helloworld-gcc13.2-distroless
+        run: |
+          du -sh .unikraft/build/ || true
+          find .unikraft/build/ -type f -name "*.img" -exec du -h {} + || true
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          scan-ref: "examples/helloworld-gcc13.2-distroless"
+          format: "table"
+          exit-code: "0"
+          severity: "CRITICAL,HIGH"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          sudo chmod 666 /dev/kvm
+
+      - name: Run and Validate Output
+        working-directory: examples/helloworld-gcc13.2-distroless
+        run: |
+          kraft run --rm -M 128M | grep -q "Bye, World!"

--- a/examples/helloworld-gcc13.2-distroless/Dockerfile
+++ b/examples/helloworld-gcc13.2-distroless/Dockerfile
@@ -1,0 +1,15 @@
+FROM gcc:13.2.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./helloworld.c /src/helloworld.c
+
+RUN set -xe; \
+    gcc \
+    -Wall -Wextra \
+    -fPIC -pie \
+    -o /helloworld helloworld.c
+
+FROM gcr.io/distroless/cc-debian13:latest
+
+COPY --from=build /helloworld /helloworld

--- a/examples/helloworld-gcc13.2-distroless/Kraftfile
+++ b/examples/helloworld-gcc13.2-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: helloworld-gcc13.2-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/helloworld"]

--- a/examples/helloworld-gcc13.2-distroless/README.md
+++ b/examples/helloworld-gcc13.2-distroless/README.md
@@ -1,0 +1,46 @@
+# C "Hello, World!"
+
+This directory contains a C-based "Hello, World!" example using GCC 13.2.0 and a distroless runtime image on Unikraft.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm --plat qemu --arch x86_64 .
+```
+
+- If the --plat argument is left out, it defaults to qemu.
+
+- If the --arch argument is left out, it defaults to your system's CPU architecture.
+
+- Once executed, you should see a "Bye, World!" message.
+
+## Inspect and Close
+
+- To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+- To close the Unikraft instance, close the kraft process (e.g., via Ctrl+c) or run:
+
+```bash
+kraft rm <instance-name>
+```
+
+Note that depending on how you modify this example your instance may need more memory to run.
+
+To do so, use the kraft run's -M flag, for example:
+
+```bash
+kraft run --rm --plat qemu --arch x86_64 -M 256M .
+```
+
+
+

--- a/examples/helloworld-gcc13.2-distroless/helloworld.c
+++ b/examples/helloworld-gcc13.2-distroless/helloworld.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main(void)
+{
+	puts("Bye, World!");
+
+	return 0;
+}


### PR DESCRIPTION
## Description

Added a C 13.2 "Hello, World!" example using the Distroless container image, providing a minimal runtime environment with only the dependencies required by the application.

This example is based on the existing `helloworld-gcc13.2` catalog example, with the container build adapted to use a multi-stage Dockerfile. The resulting image contains only the compiled binary and its required runtime libraries.

The `README.md` file contains instructions for building and running the example manually.

## Automated Testing

The second commit of this PR contains a three-stage workflow to build and test this example via GitHub Actions:

1. Measuring the `rootfs` size
2. Scanning for vulnerabilities using Trivy
3. Validating the application output using `grep`

The workflow builds the Unikraft image using KraftKit, installs QEMU, runs the unikernel, and validates that the expected `Bye, World!` output is produced.
