### PR TITLE
feat(examples): Add httpserver-gcc13.2-distroless example

### DIFF
--- a/.github/workflows/test-httpserver-gcc13.2-distroless.yaml
+++ b/.github/workflows/test-httpserver-gcc13.2-distroless.yaml
@@ -1,0 +1,87 @@
+name: Test HTTP Server GCC 13.2 Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-gcc13.2-distroless/**"
+      - ".github/workflows/test-httpserver-gcc13.2-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/httpserver-gcc13.2-distroless/**"
+      - ".github/workflows/test-httpserver-gcc13.2-distroless.yaml"
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        run: |
+          curl -sSfL https://get.kraftkit.sh | sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-gcc13.2-distroless
+        run: |
+          kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/httpserver-gcc13.2-distroless
+        run: |
+          du -sh .unikraft/build/ || true
+          find .unikraft/build/ -type f -name "*.img" -exec du -h {} + || true
+          find .unikraft/build/ -type f -name "*.cpio" -exec du -h {} + || true
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          scan-ref: "examples/httpserver-gcc13.2-distroless"
+          format: "table"
+          exit-code: "0"
+          severity: "CRITICAL,HIGH"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          sudo chmod 666 /dev/kvm
+
+      - name: Run and Validate HTTP Server
+        working-directory: examples/httpserver-gcc13.2-distroless
+        run: |
+          kraft run \
+            --rm \
+            -p 8080:8080 \
+            --plat qemu \
+            --arch x86_64 \
+            -M 128M \
+            . > /tmp/httpserver-gcc13.log 2>&1 &
+
+          KRAFT_PID=$!
+
+          for i in {1..120}; do
+            if ! kill -0 "$KRAFT_PID" 2>/dev/null; then
+              echo "Kraft process exited unexpectedly."
+              cat /tmp/httpserver-gcc13.log
+              exit 1
+            fi
+
+            if curl -fsS http://localhost:8080 | grep -q "Bye, World!"; then
+              echo "HTTP server validation successful."
+              kill "$KRAFT_PID" || true
+              exit 0
+            fi
+
+            sleep 1
+          done
+
+          echo "HTTP server validation failed."
+          echo "Kraft output:"
+          cat /tmp/httpserver-gcc13.log
+
+          kill "$KRAFT_PID" || true
+          exit 1

--- a/examples/httpserver-gcc13.2-distroless/Dockerfile
+++ b/examples/httpserver-gcc13.2-distroless/Dockerfile
@@ -1,0 +1,15 @@
+FROM gcc:13.2.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./http_server.c /src/http_server.c
+
+RUN set -xe; \
+    gcc \
+    -Wall -Wextra \
+    -fPIC -pie \
+    -o /http_server http_server.c
+
+FROM gcr.io/distroless/cc-debian13:latest
+
+COPY --from=build /http_server /http_server

--- a/examples/httpserver-gcc13.2-distroless/Kraftfile
+++ b/examples/httpserver-gcc13.2-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-gcc13.2-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/http_server"]

--- a/examples/httpserver-gcc13.2-distroless/README.md
+++ b/examples/httpserver-gcc13.2-distroless/README.md
@@ -1,0 +1,64 @@
+# C HTTP Web Server
+
+This directory contains a C HTTP server running on Unikraft.
+
+## Set Up
+ 
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME             KERNEL                          ARGS          CREATED       STATUS   MEM  PORTS                   PLAT
+kind_johndaniel  oci://unikraft.org/base:latest  /http_server  1 second ago  running  64M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `kind_johndanielg`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm kind_johndanielg
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 256M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-gcc13.2-distroless/http_server.c
+++ b/examples/httpserver-gcc13.2-distroless/http_server.c
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2023, Unikraft GmbH and the Unikraft Authors.
+ */
+ 
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <errno.h>
+
+#define LISTEN_PORT 8080
+static const char reply[] = "HTTP/1.1 200 OK\r\n" \
+			    "Content-Type: text/html\r\n" \
+			    "Content-Length: 12\r\n" \
+			    "Connection: close\r\n" \
+			    "\r\n" \
+			    "Bye, World!\n";
+
+#define BUFLEN 2048
+static char recvbuf[BUFLEN];
+
+int main(int argc __attribute__((unused)),
+	 char *argv[] __attribute__((unused)))
+{
+	int rc = 0;
+	int srv, client;
+	ssize_t n;
+	struct sockaddr_in srv_addr;
+
+	srv = socket(AF_INET, SOCK_STREAM, 0);
+	if (srv < 0) {
+		fprintf(stderr, "Failed to create socket: %d\n", errno);
+		goto out;
+	}
+
+	srv_addr.sin_family = AF_INET;
+	srv_addr.sin_addr.s_addr = INADDR_ANY;
+	srv_addr.sin_port = htons(LISTEN_PORT);
+
+	rc = bind(srv, (struct sockaddr *) &srv_addr, sizeof(srv_addr));
+	if (rc < 0) {
+		fprintf(stderr, "Failed to bind socket: %d\n", errno);
+		goto out;
+	}
+
+	/* Accept one simultaneous connection */
+	rc = listen(srv, 1);
+	if (rc < 0) {
+		fprintf(stderr, "Failed to listen on socket: %d\n", errno);
+		goto out;
+	}
+
+	printf("Listening on port %d...\n", LISTEN_PORT);
+	while (1) {
+		client = accept(srv, NULL, 0);
+		if (client < 0) {
+			fprintf(stderr,
+				"Failed to accept incoming connection: %d\n",
+				errno);
+			goto out;
+		}
+
+		/* Receive some bytes (ignore errors) */
+		read(client, recvbuf, BUFLEN);
+
+		/* Send reply */
+		n = write(client, reply, sizeof(reply) - 1);
+		if (n < 0)
+			fprintf(stderr, "Failed to send a reply\n");
+		else
+			printf("Sent a reply\n");
+
+		/* Close connection */
+		close(client);
+	}
+
+out:
+	return rc;
+}


### PR DESCRIPTION
## Description

Added a C HTTP server example using the `gcr.io/distroless/cc-debian13` container image, providing a minimal runtime environment while retaining the dependencies required by the application.

This example is based on the existing `httpserver-gcc13.2` catalog example and introduces a `-distroless` variant with a multi-stage Docker build. The application is compiled using `gcc:13.2.0-bookworm`, while the final filesystem is based on the Distroless C/C++ runtime image.

The `README.md` file contains instructions for building and running the example manually with `kraft`.

## Automated Testing

The second commit of this PR contains a GitHub Actions workflow to build and test the distroless variant through the following stages:

1. Building the Unikraft image using KraftKit
2. Measuring the generated rootfs size
3. Scanning the filesystem for vulnerabilities using Trivy
4. Installing QEMU and configuring `/dev/kvm`
5. Booting the Unikraft instance and validating the HTTP response using `curl`

The functional test verifies that the server successfully starts on port `8080` and returns the expected `Bye, World!` response.

The workflow was also tested independently before being included in this PR.
