### PR TITLE
feat(examples): Add httpserver-go1.21 distroless example

### DIFF
--- a/.github/workflows/test-httpserver-go1.21-distroless.yaml
+++ b/.github/workflows/test-httpserver-go1.21-distroless.yaml
@@ -1,0 +1,123 @@
+name: Test HTTP Server Go 1.21 Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-go1.21-distroless/**"
+      - ".github/workflows/test-httpserver-go1.21-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/httpserver-go1.21-distroless/**"
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        run: |
+          curl -sSfL https://get.kraftkit.sh \
+            | sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-go1.21-distroless
+        run: |
+          kraft build \
+            --plat qemu \
+            --arch x86_64 \
+            .
+
+      - name: Measure RootFS Size
+        working-directory: examples/httpserver-go1.21-distroless
+        run: |
+          echo "=== Build directory ==="
+          du -sh .unikraft/build/ || true
+
+          echo "=== Disk images ==="
+          find .unikraft/build/ \
+            -type f \
+            -name "*.img" \
+            -exec du -h {} + || true
+
+          echo "=== CPIO images ==="
+          find .unikraft/build/ \
+            -type f \
+            -name "*.cpio" \
+            -exec du -h {} + || true
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: examples/httpserver-go1.21-distroless
+          format: table
+          exit-code: 0
+          severity: CRITICAL,HIGH
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          sudo chmod 666 /dev/kvm
+
+      - name: Run and Validate HTTP Server
+        working-directory: examples/httpserver-go1.21-distroless
+        run: |
+          set -e
+
+          LOG_FILE=/tmp/httpserver-go1.21.log
+
+          echo "Starting Unikraft HTTP server..."
+
+          kraft run \
+            --rm \
+            -p 8080:8080 \
+            --plat qemu \
+            --arch x86_64 \
+            -M 512M \
+            . > "$LOG_FILE" 2>&1 &
+
+          KRAFT_PID=$!
+
+          echo "Kraft PID: $KRAFT_PID"
+          echo "Waiting for HTTP server to become ready..."
+
+          for i in {1..90}; do
+            if ! kill -0 "$KRAFT_PID" 2>/dev/null; then
+              echo "ERROR: kraft run exited unexpectedly."
+              echo
+              echo "=== Kraft log ==="
+              cat "$LOG_FILE"
+              exit 1
+            fi
+
+            if curl -fsS \
+              --max-time 2 \
+              http://localhost:8080 2>/dev/null \
+              | grep -q "Bye, World!"; then
+
+              echo "HTTP server validation successful."
+
+              kill "$KRAFT_PID" || true
+              wait "$KRAFT_PID" 2>/dev/null || true
+
+              exit 0
+            fi
+
+            echo "Attempt $i/90: HTTP server not ready yet."
+            sleep 1
+          done
+
+          echo "ERROR: HTTP server validation failed after 90 seconds."
+          echo
+          echo "=== Kraft log ==="
+          cat "$LOG_FILE"
+
+          kill "$KRAFT_PID" || true
+          wait "$KRAFT_PID" 2>/dev/null || true
+
+          exit 1

--- a/examples/httpserver-go1.21-distroless/Dockerfile
+++ b/examples/httpserver-go1.21-distroless/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.21.3-bookworm AS build
+
+WORKDIR /src
+
+COPY ./server.go /src/server.go
+
+RUN set -xe; \
+    CGO_ENABLED=1 \
+    go build \
+      -buildmode=pie \
+      -ldflags "-linkmode external -extldflags '-static-pie'" \
+      -tags netgo \
+      -o /server server.go \
+    ;
+
+FROM gcr.io/distroless/static-debian13:latest
+
+COPY --from=build /server /server

--- a/examples/httpserver-go1.21-distroless/Kraftfile
+++ b/examples/httpserver-go1.21-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-go1.21-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/server"]

--- a/examples/httpserver-go1.21-distroless/README.md
+++ b/examples/httpserver-go1.21-distroless/README.md
@@ -1,0 +1,64 @@
+# Simple Go 1.21 HTTP Web Server
+
+This directory contains a Go HTTP server running on Unikraft.
+
+## Set Up
+ 
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Hello, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME                KERNEL                          ARGS     CREATED        STATUS   MEM  PORTS                   PLAT
+determined_shabani  oci://unikraft.org/base:latest  /server  4 seconds ago  running  64M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `determined_shabani`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm determined_shabani
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 512M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-go1.21-distroless/server.go
+++ b/examples/httpserver-go1.21-distroless/server.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func hello(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintf(w, "Bye, World!\n")
+}
+ 
+func main() {
+	http.HandleFunc("/", hello)
+	fmt.Println("Listening on :8080...")
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
## Summary

Adds a Go 1.21 HTTP server example using a distroless runtime image.

### Changes

* Add `httpserver-go1.21-distroless` example.
* Build the server with Go 1.21.3.
* Use `gcr.io/distroless/static-debian13` as the runtime image.
* Add the required Kraftfile and documentation.
* Add a GitHub Actions workflow that builds the image, scans it with Trivy, and validates the HTTP server under QEMU.

### Validation

The example was tested locally with KraftKit/QEMU and the GitHub Actions workflow passes successfully.
