### PR TITLE
feat(examples): Add httpserver nodejs18-base distroless example

### DIFF
--- a/.github/workflows/test-httpserver-nodejs18-distroless.yml
+++ b/.github/workflows/test-httpserver-nodejs18-distroless.yml
@@ -1,0 +1,100 @@
+name: Test NodeJS 18 HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-nodejs18-distroless/**"
+      - ".github/workflows/test-httpserver-nodejs18-distroless.yml"
+  pull_request:
+    paths:
+      - "examples/httpserver-nodejs18-distroless/**"
+      - ".github/workflows/test-httpserver-nodejs18-distroless.yml"
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        run: curl -sSfL https://get.kraftkit.sh | sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-nodejs18-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/httpserver-nodejs18-distroless
+        run: |
+          du -sh .unikraft/build/ || true
+          find .unikraft/build/ -type f -name "*.img" -exec du -h {} + || true
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          scan-ref: "examples/httpserver-nodejs18-distroless"
+          format: "table"
+          exit-code: "0"
+          severity: "CRITICAL,HIGH"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          sudo chmod 666 /dev/kvm
+
+      - name: Start Unikernel
+        working-directory: examples/httpserver-nodejs18-distroless
+        run: |
+          kraft run \
+            --rm \
+            -M 512M \
+            --plat qemu \
+            --arch x86_64 \
+            -p 8080:8080 \
+            . > kraft-run.log 2>&1 &
+
+          echo $! > kraft.pid
+
+      - name: Wait for HTTP Server
+        working-directory: examples/httpserver-nodejs18-distroless
+        run: |
+          for i in $(seq 1 45); do
+            if curl -fsS http://127.0.0.1:8080 > response.txt; then
+              echo "HTTP server is ready."
+              break
+            fi
+
+            if [ "$i" -eq 45 ]; then
+              echo "HTTP server did not become ready."
+              cat kraft-run.log || true
+              exit 1
+            fi
+
+            sleep 2
+          done
+
+      - name: Validate HTTP Response
+        working-directory: examples/httpserver-nodejs18-distroless
+        run: |
+          cat response.txt
+          grep -Fxq "Bye, World!" response.txt
+
+      - name: Show Unikernel Logs
+        if: always()
+        working-directory: examples/httpserver-nodejs18-distroless
+        run: |
+          cat kraft-run.log || true
+
+      - name: Stop Unikernel
+        if: always()
+        working-directory: examples/httpserver-nodejs18-distroless
+        run: |
+          if [ -f kraft.pid ]; then
+            kill "$(cat kraft.pid)" 2>/dev/null || true
+          fi
+          kraft ps || true

--- a/examples/httpserver-nodejs18-distroless/Dockerfile
+++ b/examples/httpserver-nodejs18-distroless/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+
+COPY ./src /usr/src/

--- a/examples/httpserver-nodejs18-distroless/Kraftfile
+++ b/examples/httpserver-nodejs18-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-nodejs18-distroless
+
+runtime: node:18
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/httpserver-nodejs18-distroless/README.md
+++ b/examples/httpserver-nodejs18-distroless/README.md
@@ -1,0 +1,66 @@
+# NodeJS 18 HTTP Web Server
+
+This directory contains a distroless NodeJS 18 HTTP server running on Unikraft.
+
+The application uses a `scratch` root filesystem and the `node:18` Unikraft runtime.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to build and run the distroless image:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 512M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME           KERNEL                      ARGS                              CREATED         STATUS   MEM   PORTS                   PLAT
+vigorous_loon  oci://unikraft.org/node:18  /usr/bin/node /usr/src/server.js  18 seconds ago  running  488M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `vigorous_loon`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm vigorous_loon
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 1024M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-nodejs18-distroless/src/server.js
+++ b/examples/httpserver-nodejs18-distroless/src/server.js
@@ -1,0 +1,15 @@
+const http = require('http');
+
+const server = http.createServer((req, resp) => {
+  resp.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  resp.write('Bye, World!\n');
+
+  resp.end();
+})
+
+server.listen(8080, "0.0.0.0", () => {
+  console.log(`Listening on :8080...`);
+});


### PR DESCRIPTION
## Description

Added a Node.js 18 HTTP server example using a minimal Distroless container image based on `gcr.io/distroless/base-debian12`.

This example is based on the existing `httpserver-nodejs18-base` catalog example and adapts its filesystem build to a Distroless environment. The Node.js runtime binary and the required musl runtime libraries are copied from the official `node:18-alpine` image into the Distroless base image.

The application remains functionally identical and listens on port `8080`, returning `Bye, World!` for HTTP requests.

The `README.md` file contains instructions for building and running the example with Unikraft.

## Automated Testing

The second commit adds a dedicated GitHub Actions workflow for automatically building and testing the Distroless variant.

The workflow performs the following steps:

1. Installs KraftKit.
2. Builds the Unikraft image using QEMU with `x86_64` architecture.
3. Measures and reports the generated RootFS size.
4. Scans the example filesystem with Trivy for `HIGH` and `CRITICAL` vulnerabilities.
5. Installs QEMU and configures `/dev/kvm` permissions.
6. Boots the Unikernel with `kraft run`.
7. Waits for the HTTP server to become available.
8. Sends an HTTP request to port `8080`.
9. Validates that the response contains `Bye, World!`.

The workflow successfully verifies that the Distroless Node.js 18 application can be built, booted, and accessed correctly as a Unikraft unikernel.