### PR TITLE
feat(example): Add httpserver nodejs21-distroless example

### DIFF
--- a/.github/workflows/test-httpserver-nodejs21-distroless.yaml
+++ b/.github/workflows/test-httpserver-nodejs21-distroless.yaml
@@ -1,0 +1,94 @@
+name: Test Node.js 21 HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-nodejs21-distroless/**"
+      - ".github/workflows/test-httpserver-nodejs21-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/httpserver-nodejs21-distroless/**"
+      - ".github/workflows/test-httpserver-nodejs21-distroless.yaml"
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        run: |
+          curl -sSfL https://get.kraftkit.sh | \
+            sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+      - name: Build Unikernel
+        working-directory: examples/httpserver-nodejs21-distroless
+        run: |
+          kraft build --plat qemu --arch x86_64 .
+      - name: Measure rootfs size
+        working-directory: examples/httpserver-nodejs21-distroless
+        run: |
+          echo "Build directory:"
+          du -sh .unikraft/build/ || true
+          echo "Image/rootfs files:"
+          find .unikraft/build/ -type f \
+            \( -name "*.img" -o -name "*.cpio" \) \
+            -exec du -h {} + || true
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: examples/httpserver-nodejs21-distroless
+          format: table
+          exit-code: "0"
+          severity: CRITICAL,HIGH
+
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+      - name: Enable KVM
+        run: |
+          sudo chmod 666 /dev/kvm
+      - name: Run Unikernel and validate HTTP response
+        working-directory: examples/httpserver-nodejs21-distroless
+        run: |
+          set -e
+          kraft run \
+            --rm \
+            -p 8080:8080 \
+            --plat qemu \
+            --arch x86_64 \
+            -M 512M \
+            . > kraft.log 2>&1 &
+          KRAFT_PID=$!
+          echo "Waiting for Node.js HTTP server..."
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:8080 > response.txt 2>/dev/null; then
+              echo "HTTP server is ready."
+              break
+            fi
+            if ! kill -0 "$KRAFT_PID" 2>/dev/null; then
+              echo "Kraft process exited unexpectedly."
+              cat kraft.log
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "===== Kraft log ====="
+          cat kraft.log
+          if [ ! -f response.txt ]; then
+            echo "HTTP server did not become ready."
+            exit 1
+          fi
+          echo "===== HTTP response ====="
+          cat response.txt
+          if ! grep -q "Bye, World!" response.txt; then
+            echo "Unexpected HTTP response."
+            exit 1
+          fi
+          echo "HTTP response validated successfully."
+          kill "$KRAFT_PID" 2>/dev/null || true
+          wait "$KRAFT_PID" 2>/dev/null || true

--- a/examples/httpserver-nodejs21-distroless/.dockerignore
+++ b/examples/httpserver-nodejs21-distroless/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-nodejs21-distroless/.gitignore
+++ b/examples/httpserver-nodejs21-distroless/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-nodejs21-distroless/Dockerfile
+++ b/examples/httpserver-nodejs21-distroless/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:21-alpine AS node
+
+FROM gcr.io/distroless/base-debian12
+
+# Node binary
+COPY --from=node /usr/local/bin/node /usr/bin/node
+
+# Node runtime libraries
+COPY --from=node /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=node /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=node /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+
+# Node HTTP server
+COPY ./src/server.js /usr/src/server.js
+
+CMD ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/httpserver-nodejs21-distroless/Kraftfile
+++ b/examples/httpserver-nodejs21-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-nodejs21-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/httpserver-nodejs21-distroless/README.md
+++ b/examples/httpserver-nodejs21-distroless/README.md
@@ -1,0 +1,66 @@
+# Node.js 21 Web Server - Distroless
+
+This directory contains a Node.js 21 web server running on Unikraft using a minimal Distroless filesystem.
+
+The example is based on the existing `httpserver-nodejs21` catalog example and uses `gcr.io/distroless/base-debian12` as the minimal userspace environment.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 512M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME             KERNEL                      ARGS                              CREATED         STATUS   MEM   PORTS                   PLAT
+unruffled_edgar  oci://unikraft.org/node:21  /usr/bin/node /usr/src/server.js  47 seconds ago  running  488M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `unruffled_edgar`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm unruffled_edgar
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run -p 8080:8080 --plat qemu --arch x86_64 -M 1024M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-nodejs21-distroless/src/server.js
+++ b/examples/httpserver-nodejs21-distroless/src/server.js
@@ -1,0 +1,15 @@
+const http = require('http');
+
+const server = http.createServer((req, resp) => {
+  resp.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  resp.write('Bye, World!\n');
+
+  resp.end();
+})
+
+server.listen(8080, "0.0.0.0", () => {
+  console.log(`Listening on :8080...`);
+});


### PR DESCRIPTION
## Description

Added a Node.js 21 HTTP server example using a distroless container image.

The example is based on the existing `httpserver-nodejs21` catalog example and adapts it to a distroless runtime environment. The Dockerfile uses a minimal distroless base image and copies only the Node.js runtime components and application required to run the HTTP server.

The `README.md` file contains instructions for building and running the example with KraftKit, as well as how to test the HTTP server using `curl`.

## Automated Testing

The second commit of this PR adds a GitHub Actions workflow that automatically builds and tests the example.

The workflow performs the following checks:

1. Builds the Unikernel using KraftKit and QEMU.
2. Measures and reports the generated rootfs/image size.
3. Scans the example for HIGH and CRITICAL vulnerabilities using Trivy.
4. Runs the Unikernel with QEMU.
5. Sends an HTTP request to the server and validates that the expected `Bye, World!` response is returned.

The workflow is triggered on pushes and pull requests affecting the example or its workflow file, and can also be triggered manually.