### PR TITLE
feat(example): Add httpserver nodejs22 base-distroless example

### DIFF
--- a/.github/workflows/test-httpserver-nodejs22-base-distroless.yaml
+++ b/.github/workflows/test-httpserver-nodejs22-base-distroless.yaml
@@ -1,0 +1,113 @@
+name: Test Node.js 22 HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-nodejs22-base-distroless/**"
+      - ".github/workflows/test-httpserver-nodejs22-base-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/httpserver-nodejs22-base-distroless/**"
+      - ".github/workflows/test-httpserver-nodejs22-base-distroless.yaml"
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        run: |
+          curl -sSfL https://get.kraftkit.sh | \
+            sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-nodejs22-base-distroless
+        run: |
+          kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure rootfs size
+        working-directory: examples/httpserver-nodejs22-base-distroless
+        run: |
+          echo "Build directory:"
+          du -sh .unikraft/build/ || true
+
+          echo "Image/rootfs files:"
+          find .unikraft/build/ -type f \
+            \( -name "*.img" -o -name "*.cpio" \) \
+            -exec du -h {} + || true
+
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: examples/httpserver-nodejs22-base-distroless
+          format: table
+          exit-code: "0"
+          severity: CRITICAL,HIGH
+
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+
+      - name: Enable KVM
+        run: |
+          sudo chmod 666 /dev/kvm
+
+      - name: Run Unikernel and validate HTTP response
+        working-directory: examples/httpserver-nodejs22-base-distroless
+        run: |
+          set -e
+
+          kraft run \
+            --rm \
+            -p 8080:8080 \
+            --plat qemu \
+            --arch x86_64 \
+            -M 1024M \
+            . > kraft.log 2>&1 &
+
+          KRAFT_PID=$!
+
+          echo "Waiting for Node.js HTTP server..."
+
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:8080 > response.txt 2>/dev/null; then
+              echo "HTTP server is ready."
+              break
+            fi
+
+            if ! kill -0 "$KRAFT_PID" 2>/dev/null; then
+              echo "Kraft process exited unexpectedly."
+              cat kraft.log
+              exit 1
+            fi
+
+            sleep 2
+          done
+
+          echo "===== Kraft log ====="
+          cat kraft.log
+
+          if [ ! -f response.txt ]; then
+            echo "HTTP server did not become ready."
+            exit 1
+          fi
+
+          echo "===== HTTP response ====="
+          cat response.txt
+
+          if ! grep -q "Bye, World!" response.txt; then
+            echo "Unexpected HTTP response."
+            exit 1
+          fi
+
+          echo "HTTP response validated successfully."
+
+          kill "$KRAFT_PID" 2>/dev/null || true
+          wait "$KRAFT_PID" 2>/dev/null || true
+          

--- a/examples/httpserver-nodejs22-base-distroless/.dockerignore
+++ b/examples/httpserver-nodejs22-base-distroless/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-nodejs22-base-distroless/.gitignore
+++ b/examples/httpserver-nodejs22-base-distroless/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-nodejs22-base-distroless/Dockerfile
+++ b/examples/httpserver-nodejs22-base-distroless/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-alpine AS node
+
+FROM scratch
+
+# Dynamic linker
+COPY --from=node /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+
+# Node binary
+COPY --from=node /usr/local/bin/node /usr/bin/node
+
+# Required libraries
+COPY --from=node /usr/lib /usr/lib
+
+# Node HTTP server
+COPY ./src /usr/src
+
+CMD ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/httpserver-nodejs22-base-distroless/Kraftfile
+++ b/examples/httpserver-nodejs22-base-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-nodejs22-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/httpserver-nodejs22-base-distroless/README.md
+++ b/examples/httpserver-nodejs22-base-distroless/README.md
@@ -1,0 +1,64 @@
+# Node 22 Web Server
+
+This directory contains a Node.js 22 web server running on Unikraft using a distroless container image.
+
+## Set Up
+
+To run this example, install Unikraft's companion command-line toolchain `kraft`, clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 512M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME             KERNEL                      ARGS                              CREATED         STATUS   MEM   PORTS                   PLAT
+unruffled_edgar  oci://unikraft.org/node:22  /usr/bin/node /usr/src/server.js  47 seconds ago  running  488M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `unruffled_edgar`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm unruffled_edgar
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run -p 8080:8080 --plat qemu --arch x86_64 -M 1024M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-nodejs22-base-distroless/src/server.js
+++ b/examples/httpserver-nodejs22-base-distroless/src/server.js
@@ -1,0 +1,15 @@
+const http = require('http');
+
+const server = http.createServer((req, resp) => {
+  resp.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  resp.write('Bye, World!\n');
+
+  resp.end();
+})
+
+server.listen(8080, "0.0.0.0", () => {
+  console.log(`Listening on :8080...`);
+});


### PR DESCRIPTION
## Description

Added a Node.js 22 HTTP server example using a distroless container image based on `node:22-bookworm-slim`, providing a minimal runtime environment with the dependencies required by Node.js. This example is based on the existing Node.js HTTP server example in the catalog, adapting the container build to use a distroless image.

The `README.md` file contains instructions for building and running the example manually with KraftKit.

## Automated Testing

The second commit of this PR contains a workflow to build and test this example via GitHub Actions:

1. Building the Unikernel using KraftKit for QEMU/x86_64
2. Measuring the `rootfs` size
3. Scanning for vulnerabilities using Trivy
4. Running the Unikernel with QEMU
5. Validating the HTTP server response using `curl` and checking for the expected `Bye, World!` output