### PR TITLE
feat(Examples): Add httpserver nodejs25 base-distroless example

### DIFF
--- a/.github/workflows/test-httpserver-nodejs25-base-distroless.yaml
+++ b/.github/workflows/test-httpserver-nodejs25-base-distroless.yaml
@@ -1,0 +1,112 @@
+name: Test Node.js 25 HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-nodejs25-base-distroless/**"
+      - ".github/workflows/test-httpserver-nodejs25-base-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/httpserver-nodejs25-base-distroless/**"
+      - ".github/workflows/test-httpserver-nodejs25-base-distroless.yaml"
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        run: |
+          curl -sSfL https://get.kraftkit.sh | \
+            sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-nodejs25-base-distroless
+        run: |
+          kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure rootfs size
+        working-directory: examples/httpserver-nodejs25-base-distroless
+        run: |
+          echo "Build directory:"
+          du -sh .unikraft/build/ || true
+
+          echo "Image/rootfs files:"
+          find .unikraft/build/ -type f \
+            \( -name "*.img" -o -name "*.cpio" \) \
+            -exec du -h {} + || true
+
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: examples/httpserver-nodejs25-base-distroless
+          format: table
+          exit-code: "0"
+          severity: CRITICAL,HIGH
+
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+
+      - name: Enable KVM
+        run: |
+          sudo chmod 666 /dev/kvm
+
+      - name: Run Unikernel and validate HTTP response
+        working-directory: examples/httpserver-nodejs25-base-distroless
+        run: |
+          set -e
+
+          kraft run \
+            --rm \
+            -p 8080:8080 \
+            --plat qemu \
+            --arch x86_64 \
+            -M 1024M \
+            . > kraft.log 2>&1 &
+
+          KRAFT_PID=$!
+
+          echo "Waiting for Node.js HTTP server..."
+
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:8080 > response.txt 2>/dev/null; then
+              echo "HTTP server is ready."
+              break
+            fi
+
+            if ! kill -0 "$KRAFT_PID" 2>/dev/null; then
+              echo "Kraft process exited unexpectedly."
+              cat kraft.log
+              exit 1
+            fi
+
+            sleep 2
+          done
+
+          echo "===== Kraft log ====="
+          cat kraft.log
+
+          if [ ! -f response.txt ]; then
+            echo "HTTP server did not become ready."
+            exit 1
+          fi
+
+          echo "===== HTTP response ====="
+          cat response.txt
+
+          if ! grep -q "Bye, World!" response.txt; then
+            echo "Unexpected HTTP response."
+            exit 1
+          fi
+
+          echo "HTTP response validated successfully."
+
+          kill "$KRAFT_PID" 2>/dev/null || true
+          wait "$KRAFT_PID" 2>/dev/null || true

--- a/examples/httpserver-nodejs25-base-distroless/.dockerignore
+++ b/examples/httpserver-nodejs25-base-distroless/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-nodejs25-base-distroless/.gitignore
+++ b/examples/httpserver-nodejs25-base-distroless/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-nodejs25-base-distroless/Dockerfile
+++ b/examples/httpserver-nodejs25-base-distroless/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:25-alpine3.22 AS node
+
+FROM alpine:3.22 AS sys
+
+RUN set -xe; \
+    mkdir -p /target/etc; \
+    mkdir -p /blank; \
+    apk --no-cache add \
+    ca-certificates \
+    tzdata \
+    ; \
+    update-ca-certificates; \
+    ln -sf ../usr/share/zoneinfo/Etc/UTC /target/etc/localtime; \
+    echo "Etc/UTC" > /target/etc/timezone;
+
+FROM scratch
+
+COPY --from=sys /target/etc /etc
+COPY --from=sys /usr/share/zoneinfo/Etc/UTC /usr/share/zoneinfo/Etc/UTC
+COPY --from=sys /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=sys /blank /tmp
+
+# Node binary
+COPY --from=node /usr/local/bin/node /usr/bin/node
+
+# System libraries
+COPY --from=node /etc/ssl/openssl.cnf /etc/ssl/openssl.cnf
+COPY --from=node /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=node /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=node /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+
+# Node HTTP server
+COPY ./src /usr/src

--- a/examples/httpserver-nodejs25-base-distroless/Kraftfile
+++ b/examples/httpserver-nodejs25-base-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-nodejs25-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/httpserver-nodejs25-base-distroless/README.md
+++ b/examples/httpserver-nodejs25-base-distroless/README.md
@@ -1,0 +1,60 @@
+# Node 25 Web Server
+
+This directory contains a Node.js 25 web server running on Unikraft using a minimal distroless-style root filesystem.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to build and run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 1024M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a `Bye, World!` message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm <instance-name>
+```
+
+Note that depending on how you modify this example, your instance may need more memory to run. To increase the allocated memory, use the `kraft run` `-M` flag, for example:
+
+```bash
+kraft run -p 8080:8080 --plat qemu --arch x86_64 -M 2048M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+
+Read more about how to start `kraft` without `sudo` at [Running KraftKit without sudo](https://unikraft.org/sudoless).
+
+## Learn More
+
+* [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+* [Building Dockerfile Images with BuildKit](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-nodejs25-base-distroless/src/server.js
+++ b/examples/httpserver-nodejs25-base-distroless/src/server.js
@@ -1,0 +1,15 @@
+const http = require('http');
+
+const server = http.createServer((req, resp) => {
+  resp.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  resp.write('Bye, World!\n');
+
+  resp.end();
+})
+
+server.listen(8080, "0.0.0.0", () => {
+  console.log(`Listening on :8080...`);
+});


### PR DESCRIPTION
## Description

Added a Node.js 25 HTTP server example using a distroless container image based on Alpine Linux. The example provides a minimal runtime environment containing only the Node.js binary, required system libraries, certificates, timezone data, and the HTTP server source.

The `README.md` file contains instructions for building and running the example manually with Unikraft.

## Automated Testing

The second commit of this PR contains a three-stage workflow to build and test the example via GitHub Actions:

1. Building the Unikraft image and measuring the resulting `rootfs` size
2. Scanning the example for `HIGH` and `CRITICAL` vulnerabilities using Trivy
3. Running the Node.js 25 HTTP server with QEMU and validating the `Bye, World!` HTTP response
