### PR TITLE
feat(examples): Add httpserver-python3.10-base-distroless example

### DIFF
--- a/.github/workflows/test-httpserver-python3.10-base-distroless.yaml
+++ b/.github/workflows/test-httpserver-python3.10-base-distroless.yaml
@@ -1,0 +1,112 @@
+name: Test Python 3.10 HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-python3.10-base-distroless/**"
+      - ".github/workflows/test-httpserver-python3.10-base-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/httpserver-python3.10-base-distroless/**"
+      - ".github/workflows/test-httpserver-python3.10-base-distroless.yaml"
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        run: |
+          curl -sSfL https://get.kraftkit.sh | \
+            sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-python3.10-base-distroless
+        run: |
+          kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure rootfs size
+        working-directory: examples/httpserver-python3.10-base-distroless
+        run: |
+          echo "Build directory:"
+          du -sh .unikraft/build/ || true
+
+          echo "Image/rootfs files:"
+          find .unikraft/build/ -type f \
+            \( -name "*.img" -o -name "*.cpio" \) \
+            -exec du -h {} + || true
+
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: examples/httpserver-python3.10-base-distroless
+          format: table
+          exit-code: "0"
+          severity: CRITICAL,HIGH
+
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+
+      - name: Enable KVM
+        run: |
+          sudo chmod 666 /dev/kvm
+
+      - name: Run Unikernel and validate HTTP response
+        working-directory: examples/httpserver-python3.10-base-distroless
+        run: |
+          set -e
+
+          kraft run \
+            --rm \
+            -p 8080:8080 \
+            --plat qemu \
+            --arch x86_64 \
+            -M 512M \
+            . > kraft.log 2>&1 &
+
+          KRAFT_PID=$!
+
+          echo "Waiting for Python HTTP server..."
+
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:8080 > response.txt 2>/dev/null; then
+              echo "HTTP server is ready."
+              break
+            fi
+
+            if ! kill -0 "$KRAFT_PID" 2>/dev/null; then
+              echo "Kraft process exited unexpectedly."
+              cat kraft.log
+              exit 1
+            fi
+
+            sleep 2
+          done
+
+          echo "===== Kraft log ====="
+          cat kraft.log
+
+          if [ ! -f response.txt ]; then
+            echo "HTTP server did not become ready."
+            exit 1
+          fi
+
+          echo "===== HTTP response ====="
+          cat response.txt
+
+          if ! grep -q "Bye, World!" response.txt; then
+            echo "Unexpected HTTP response."
+            exit 1
+          fi
+
+          echo "HTTP response validated successfully."
+
+          kill "$KRAFT_PID" 2>/dev/null || true
+          wait "$KRAFT_PID" 2>/dev/null || true

--- a/examples/httpserver-python3.10-base-distroless/Dockerfile
+++ b/examples/httpserver-python3.10-base-distroless/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.10.11-slim-bullseye AS python
+
+FROM gcr.io/distroless/base-debian12
+
+# Python executable and standard library
+COPY --from=python /usr/local/bin/python3 /usr/local/bin/python3
+COPY --from=python /usr/local/lib/python3.10 /usr/local/lib/python3.10
+
+# Python shared library
+COPY --from=python /usr/local/lib/libpython3.10.so.1.0 /usr/local/lib/libpython3.10.so.1.0
+
+# System libraries
+COPY --from=python /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=python /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=python /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=python /lib/x86_64-linux-gnu/libutil.so.1 /lib/x86_64-linux-gnu/libutil.so.1
+COPY --from=python /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=python /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+
+# Dynamic linker
+COPY --from=python /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+# Application
+COPY ./server.py /server.py
+
+CMD ["/usr/local/bin/python3", "/server.py"]

--- a/examples/httpserver-python3.10-base-distroless/Kraftfile
+++ b/examples/httpserver-python3.10-base-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-python3.10-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/local/bin/python3", "/server.py"]

--- a/examples/httpserver-python3.10-base-distroless/README.md
+++ b/examples/httpserver-python3.10-base-distroless/README.md
@@ -1,0 +1,66 @@
+# Python HTTP Server
+
+This directory contains a Python 3.10 HTTP server running on Unikraft using a minimal distroless container image.
+
+The example uses Python 3.10 and packages the Python runtime and required system libraries into a minimal container image, which is then used as the root filesystem for the Unikraft unikernel.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 256M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME                      KERNEL                          ARGS        CREATED         STATUS   MEM   PORTS                   PLAT
+inspiring_davidgreybeard  oci://unikraft.org/python:3.10  /server.py  16 seconds ago  running  244M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `inspiring_dadidgreybeard`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm inspiring_dadidgreybeard
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 512M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/examples/httpserver-python3.10-base-distroless/server.py
+++ b/examples/httpserver-python3.10-base-distroless/server.py
@@ -1,0 +1,31 @@
+import argparse
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class MyServer(BaseHTTPRequestHandler):
+  def do_GET(self):
+    self.send_response(200)
+    self.send_header("Content-type", "text/html")
+    self.end_headers()
+    self.wfile.write(bytes("Bye, World!", "utf-8"))
+
+def main(args):
+  server = HTTPServer((args.host, args.port), MyServer)
+
+  print("starting server at %s:%s" % (args.host, args.port))
+
+  try:
+    server.serve_forever()
+
+  except KeyboardInterrupt:
+    pass
+
+  print("server stopped")
+
+def parse_args():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--host", type=str, default="0.0.0.0")
+  parser.add_argument("--port", type=int, default=8080)
+  return parser.parse_args()
+
+if __name__ == "__main__":
+  main(parse_args())


### PR DESCRIPTION
## Description

Added a Python 3.10 HTTP server example using a minimal distroless container image for Unikraft.

The example packages the Python runtime and required system libraries into the distroless image and includes a `README.md` with instructions for building and running the example manually.

## Automated Testing

The second commit adds a GitHub Actions workflow that:

1. Builds the Unikraft image using KraftKit
2. Measures the generated rootfs size
3. Scans the example for CRITICAL and HIGH vulnerabilities using Trivy
4. Runs the unikernel with QEMU and validates the HTTP response using `curl` and `grep`
