### PR TITLE
feat(examples): Add database-redis7.2-base-distroless example

### DIFF
--- a/.github/workflows/test-database-redis7.2-base-distroless.yaml
+++ b/.github/workflows/test-database-redis7.2-base-distroless.yaml
@@ -1,0 +1,92 @@
+name: Test Redis7.2 Database Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/database-redis7.2-base-distroless/**"
+      - ".github/workflows/test-database-redis7.2-base-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/database-redis7.2-base-distroless/**"
+      - ".github/workflows/test-database-redis7.2-base-distroless.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+          awk -v f="kraft_${KRAFT_VERSION}_linux_amd64.tar.gz" '($2==f)||($2=="*"f){print}' "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/database-redis7.2-base-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/database-redis7.2-base-distroless
+        run: |
+          du -sh .unikraft/build/initramfs-x86_64.cpio
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/database-redis7.2-base-distroless
+        run: docker build --pull -t database-redis7.2-base-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          image-ref: "database-redis7.2-base-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/database-redis7.2-base-distroless/.trivyignore"
+
+      - name: Install QEMU and Redis
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86 redis-tools
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run Unikernel in Background
+        working-directory: examples/database-redis7.2-base-distroless
+        run: kraft run -d --rm -p 6379:6379 --plat qemu --arch x86_64 -M 256M --name redis-test .
+
+      - name: Test Database
+        run: |
+          sleep 5
+          redis-cli -h 127.0.0.1 -p 6379 SET a 1
+          RESULT=$(redis-cli -h 127.0.0.1 -p 6379 GET a)
+          if [ "$RESULT" = "1" ]; then
+            exit 0
+          else
+            exit 1
+          fi
+
+      - name: Cleanup
+        if: always()
+        run: kraft rm --force redis-test || true

--- a/examples/database-redis7.2-base-distroless/.dockerignore
+++ b/examples/database-redis7.2-base-distroless/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/database-redis7.2-base-distroless/.gitignore
+++ b/examples/database-redis7.2-base-distroless/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/database-redis7.2-base-distroless/.trivyignore
+++ b/examples/database-redis7.2-base-distroless/.trivyignore
@@ -1,0 +1,3 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30

--- a/examples/database-redis7.2-base-distroless/Dockerfile
+++ b/examples/database-redis7.2-base-distroless/Dockerfile
@@ -1,0 +1,9 @@
+FROM redis:7.2.2-bookworm AS build
+
+FROM gcr.io/distroless/cc-debian12@sha256:e5d81ddde149641e2a9ba55be4545bc125c67de07508b03ba4c22e6eb0ded5aa
+
+# Redis binaries, modules, configuration, log and runtime files
+COPY --from=build /usr/local/bin/redis-server /usr/bin/redis-server
+
+# Custom configuration files, including using a single process for Redis
+COPY ./redis.conf /etc/redis/redis.conf

--- a/examples/database-redis7.2-base-distroless/Kraftfile
+++ b/examples/database-redis7.2-base-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: database-redis7.2-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/redis-server", "/etc/redis/redis.conf"]

--- a/examples/database-redis7.2-base-distroless/README.md
+++ b/examples/database-redis7.2-base-distroless/README.md
@@ -1,0 +1,62 @@
+# Redis - Distroless
+
+This example demonstrates how to use [`Redis`](https://redis.io), an open-source in-memory storage, used as a distributed, in-memory key–value database, cache and message broker, with optional durability. It runs on Unikraft using the `gcr.io/distroless/cc-debian12` base image. This minimal environment lacks a shell and unnecessary system utilities, significantly reducing the attack surface.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 6379:6379 --plat qemu --arch x86_64 -M 256M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Then use `redis-cli` to test the connection:
+
+```console
+redis-cli set a 1
+redis-cli get a
+```
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME           KERNEL                          ARGS                                       CREATED        STATUS   MEM   PORTS                   PLAT
+heuristic_moe  oci://unikraft.org/base:latest  /usr/bin/redis-server /etc/redis/redis...  5 seconds ago  running  244M  0.0.0.0:6379->6379/tcp  qemu/x86_64
+```
+
+The instance name is `heuristic_moe`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm heuristic_moe
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 6379:6379 --plat qemu --arch x86_64 -M 512M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/database-redis7.2-base-distroless/redis.conf
+++ b/examples/database-redis7.2-base-distroless/redis.conf
@@ -1,0 +1,6 @@
+bind 0.0.0.0
+port 6379
+tcp-backlog 511
+daemonize no
+timeout 0
+tcp-keepalive 300


### PR DESCRIPTION
## Description

Added a Redis 7.2 database example using the distroless container image `cc-debian12`, which provides a minimal environment with sufficient dependencies. This example is based on the existing one in the catalog, enhancing the container build via distroless.

The `README.md` file contains instructions for building and running the example manually.

## Automated Testing

The second commit of this PR contains a three-stage workflow to build and test this example via GitHub Actions:

1. Measuring the `rootfs` size (resulting in 38MB)
2. Scanning for vulnerabilities using Trivy
3. Validating the database operations using `redis-cli`

### Note on Vulnerability Scanning:

Trivy scans are configured to pass by explicitly ignoring `CVE-2026-14456` (libssl3) via `.trivyignore`. This vulnerability affects OpenSSL QUIC servers, a feature that this simple application does not implement or utilize. Furthermore, there is currently no official upstream Debian fix available for the base image. This exception and the non-clean base state are explicitly acknowledged here.