### PR TITLE
Feat/duckdb go1.21 distroless

### DIFF
--- a/.github/workflows/test-duckdb-go1.21-distroless.yaml
+++ b/.github/workflows/test-duckdb-go1.21-distroless.yaml
@@ -1,0 +1,95 @@
+name: Test DuckDB Go 1.21 Distroless
+
+on:
+  push:
+    paths:
+      - "examples/duckdb-go1.21-distroless/**"
+      - ".github/workflows/test-duckdb-go1.21-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/duckdb-go1.21-distroless/**"
+      - ".github/workflows/test-duckdb-go1.21-distroless.yaml"
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        run: |
+          curl -sSfL https://get.kraftkit.sh \
+            | sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Build Unikernel
+        working-directory: examples/duckdb-go1.21-distroless
+        run: |
+          kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/duckdb-go1.21-distroless
+        run: |
+          du -sh .unikraft/build/ || true
+          find .unikraft/build/ \
+            -type f \( -name "*.img" -o -name "*.elf" \) \
+            -exec du -h {} + || true
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: examples/duckdb-go1.21-distroless
+          format: table
+          exit-code: 0
+          severity: CRITICAL,HIGH
+
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          sudo chmod 666 /dev/kvm || true
+
+      - name: Run and Validate DuckDB
+        working-directory: examples/duckdb-go1.21-distroless
+        run: |
+          set -euxo pipefail
+
+          kraft run \
+            --rm \
+            --plat qemu \
+            --arch x86_64 \
+            -M 512M \
+            -p 8080:8080 \
+            . > kraft.log 2>&1 &
+
+          KRAFT_PID=$!
+
+          for i in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8080 > response.txt 2>/dev/null; then
+              break
+            fi
+
+            if ! kill -0 "$KRAFT_PID" 2>/dev/null; then
+              cat kraft.log
+              exit 1
+            fi
+
+            sleep 1
+          done
+
+          test -s response.txt
+          cat response.txt
+
+          grep -F "42" response.txt
+          grep -F "John" response.txt
+
+          kill "$KRAFT_PID" 2>/dev/null || true
+
+      - name: Show Kraft log
+        if: always()
+        working-directory: examples/duckdb-go1.21-distroless
+        run: |
+          cat kraft.log || true

--- a/examples/duckdb-go1.21-distroless/.dockerignore
+++ b/examples/duckdb-go1.21-distroless/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/duckdb-go1.21-distroless/.gitignore
+++ b/examples/duckdb-go1.21-distroless/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/duckdb-go1.21-distroless/Dockerfile
+++ b/examples/duckdb-go1.21-distroless/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.21.3-bookworm AS build
+
+WORKDIR /src
+
+COPY ./src/go.mod ./src/go.sum ./
+
+RUN go mod download
+
+COPY ./src/ ./
+
+RUN CGO_ENABLED=1 go build \
+    -buildmode=pie \
+    -ldflags "-linkmode external -extldflags -static-pie" \
+    -tags netgo \
+    -o /server \
+    .
+
+FROM scratch
+
+COPY --from=build /server /server

--- a/examples/duckdb-go1.21-distroless/Kraftfile
+++ b/examples/duckdb-go1.21-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: duckdb-go1.21-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/server"]

--- a/examples/duckdb-go1.21-distroless/README.md
+++ b/examples/duckdb-go1.21-distroless/README.md
@@ -1,0 +1,134 @@
+# DuckDB using Go SDK - Distroless
+
+This example demonstrates how to use [`DuckDB`](https://duckdb.org), an in-process SQL OLAP database management system, in a Go project running on Unikraft with a minimal distroless root filesystem.
+
+The application uses the [`go-duckdb`](https://github.com/marcboeker/go-duckdb) Go SDK to create a table, insert a record, query the database, and expose the result through an HTTP server.
+
+The final root filesystem is built from `scratch`, containing only the application binary required to run the service.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+The source code and Go module files are located under the `src/` directory:
+
+```text
+duckdb-go1.21-distroless/
+├── Dockerfile
+├── Kraftfile
+└── src/
+    ├── go.mod
+    ├── go.sum
+    └── main.go
+```
+
+The `Dockerfile` uses a multi-stage build. The Go application is compiled using `golang:1.21.3-bookworm`, while the final stage uses `scratch` and contains only the resulting `/server` binary.
+
+## Run and Use
+
+Use `kraft` to build the distroless root filesystem and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 256M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, the application will start an HTTP server on port `8080`.
+
+The application creates a DuckDB table, inserts the following record:
+
+```text
+id: 42
+name: John
+```
+
+To test the HTTP server, use `curl`:
+
+```bash
+curl localhost:8080/
+```
+
+You should see:
+
+```text
+id: 42, name: John
+```
+
+## Distroless Root Filesystem
+
+Unlike the original example, this variant does not include the Go build environment or a full Linux distribution in the final root filesystem.
+
+The application is built in a separate stage and copied into a minimal `scratch` image:
+
+```dockerfile
+FROM golang:1.21.3-bookworm AS build
+
+WORKDIR /src
+
+COPY ./src/go.mod ./src/go.sum ./
+
+RUN go mod download
+
+COPY ./src/ ./
+
+RUN CGO_ENABLED=1 go build \
+    -buildmode=pie \
+    -ldflags "-linkmode external -extldflags -static-pie" \
+    -tags netgo \
+    -o /server \
+    .
+
+FROM scratch
+
+COPY --from=build /server /server
+```
+
+This keeps the final root filesystem minimal and removes unnecessary runtime components such as a shell, package manager, and other Debian userspace files.
+
+## Inspect and Close
+
+To list information about the running Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+For example:
+
+```text
+NAME        KERNEL                   ARGS     CREATED        STATUS   MEM   PORTS                   PLAT
+
+sharp_jack  oci://unikraft.org/base:latest  /server  27 seconds ago  running  256M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `sharp_jack`.
+
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm sharp_jack
+```
+
+Note that depending on how you modify this example, your instance may need more memory to run.
+
+To increase the amount of memory available to the instance, use the `kraft run`'s `-M` flag:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 512M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+
+Read more about how to start `kraft` without `sudo` at https://unikraft.org/sudoless.
+
+## Learn More
+
+* [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+* [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)
+* [DuckDB](https://duckdb.org)
+* [go-duckdb](https://github.com/marcboeker/go-duckdb)

--- a/examples/duckdb-go1.21-distroless/src/go.mod
+++ b/examples/duckdb-go1.21-distroless/src/go.mod
@@ -1,0 +1,7 @@
+module github.com/kraftcloud/examples/duckdb-go
+
+go 1.21.1
+
+require github.com/marcboeker/go-duckdb v1.5.4
+
+require github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/examples/duckdb-go1.21-distroless/src/go.sum
+++ b/examples/duckdb-go1.21-distroless/src/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/marcboeker/go-duckdb v1.5.4 h1:Cv6gzgrzPnmqJKJiTT2CJM3eUqIT5in9DNyxAn+okgA=
+github.com/marcboeker/go-duckdb v1.5.4/go.mod h1:wm91jO2GNKa6iO9NTcjXIRsW+/ykPoJbQcHSXhdAl28=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/duckdb-go1.21-distroless/src/main.go
+++ b/examples/duckdb-go1.21-distroless/src/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+
+	_ "github.com/marcboeker/go-duckdb"
+)
+
+func main() {
+	db, _ := sql.Open("duckdb", "")
+
+	db.Exec(`CREATE TABLE person (id INTEGER, name VARCHAR)`)
+	db.Exec(`INSERT INTO person VALUES (42, 'John')`)
+
+	var (
+		id   int
+		name string
+	)
+	row := db.QueryRow(`SELECT id, name FROM person`)
+	_ = row.Scan(&id, &name)
+	fmt.Println("id:", id, "name:", name)
+
+	// Serve the print on port 8080 as a http server
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "id: %d, name: %s", id, name)
+	})
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
## Description

Add a distroless variant of the `duckdb-go1.21` example.

## Changes

- Add `duckdb-go1.21-distroless` example.
- Build the Go application as a static PIE binary.
- Use `scratch` as the final runtime image.
- Add the required `Kraftfile` and `README.md`.
- Add a GitHub Actions workflow to build and test the example.

## Testing

The example was tested successfully with KraftKit and QEMU, and the GitHub Actions workflow passes successfully.