### PR TITLE
feat(examples): Add skipper0.18-distroless example

### DIFF
--- a/.github/workflows/test-skipper0.18-distroless.yaml
+++ b/.github/workflows/test-skipper0.18-distroless.yaml
@@ -1,0 +1,133 @@
+name: Test Skipper 0.18 Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/skipper0.18-distroless/**"
+      - ".github/workflows/test-skipper0.18-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/skipper0.18-distroless/**"
+      - ".github/workflows/test-skipper0.18-distroless.yaml"
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        run: |
+          curl -sSfL https://get.kraftkit.sh | \
+            sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Build Unikernel
+        working-directory: examples/skipper0.18-distroless
+        run: |
+          kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure rootfs size
+        working-directory: examples/skipper0.18-distroless
+        run: |
+          echo "Build directory:"
+          du -sh .unikraft/build/ || true
+
+          echo "Image/rootfs files:"
+          find .unikraft/build/ -type f \
+            \( -name "*.img" -o -name "*.cpio" \) \
+            -exec du -h {} + || true
+
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: examples/skipper0.18-distroless
+          format: table
+          exit-code: "0"
+          severity: CRITICAL,HIGH
+
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+
+      - name: Enable KVM
+        run: |
+          sudo chmod 666 /dev/kvm
+
+      - name: Run Unikernel and validate HTTP response
+        working-directory: examples/skipper0.18-distroless
+        run: |
+          set -e
+
+          kraft run \
+            --rm \
+            -p 9090:9090 \
+            --plat qemu \
+            --arch x86_64 \
+            -M 512M \
+            . > kraft.log 2>&1 &
+
+          KRAFT_PID=$!
+
+          echo "Waiting for Skipper HTTP server..."
+
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:9090 > response.txt 2>/dev/null; then
+              echo "Skipper HTTP server is ready."
+              break
+            fi
+
+            if ! kill -0 "$KRAFT_PID" 2>/dev/null; then
+              echo "Kraft process exited unexpectedly."
+              cat kraft.log
+              exit 1
+            fi
+
+            sleep 2
+          done
+
+          echo "===== Kraft log ====="
+          cat kraft.log
+
+          if [ ! -f response.txt ]; then
+            echo "Skipper HTTP server did not become ready."
+            exit 1
+          fi
+
+          echo "===== HTTP response ====="
+          cat response.txt
+
+          if ! grep -q "Bye, World!" response.txt; then
+            echo "Unexpected HTTP response."
+            exit 1
+          fi
+
+          echo "Root route validated successfully."
+
+          echo "===== Testing 404 route ====="
+
+          HTTP_STATUS=$(curl -sS -o not-found.txt -w "%{http_code}" \
+            http://127.0.0.1:9090/test)
+
+          echo "HTTP status: $HTTP_STATUS"
+          echo "HTTP response:"
+          cat not-found.txt
+
+          if [ "$HTTP_STATUS" != "404" ]; then
+            echo "Unexpected HTTP status for /test."
+            exit 1
+          fi
+
+          if ! grep -q "No route entry" not-found.txt; then
+            echo "Unexpected HTTP response for /test."
+            exit 1
+          fi
+
+          echo "404 route validated successfully."
+
+          kill "$KRAFT_PID" 2>/dev/null || true
+          wait "$KRAFT_PID" 2>/dev/null || true

--- a/examples/skipper0.18-distroless/Dockerfile
+++ b/examples/skipper0.18-distroless/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+
+COPY example.eskip /etc/skipper/example.eskip

--- a/examples/skipper0.18-distroless/Kraftfile
+++ b/examples/skipper0.18-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: skipper0.18-distroless
+
+runtime: skipper:0.18
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/skipper", "-routes-file", "/etc/skipper/example.eskip"]

--- a/examples/skipper0.18-distroless/README.md
+++ b/examples/skipper0.18-distroless/README.md
@@ -1,0 +1,73 @@
+
+# Skipper 0.18
+
+This example demonstrates how to run Skipper 0.18 as a distroless unikernel with Unikraft.
+
+## Build and Run
+
+To build and run the example, use:
+
+```console
+kraft run --rm -p 9090:9090 --plat qemu --arch x86_64 -M 512M .
+```
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 9090:9090 --plat qemu --arch x86_64 -M 512M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `9090` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:9090
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME          KERNEL                           ARGS                                                      CREATED         STATUS   MEM   PORTS                   PLAT
+tender_manis  oci://unikraft.org/skipper:0.18  /usr/bin/skipper -routes-file /etc/skipper/example.eskip  11 seconds ago  running  488M  0.0.0.0:9090->9090/tcp  qemu/x86_64
+```
+
+The instance name is `tender_manis`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm tender_manis
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 9090:9090 --plat qemu --arch x86_64 -M 1024M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/skipper0.18-distroless/example.eskip
+++ b/examples/skipper0.18-distroless/example.eskip
@@ -1,0 +1,10 @@
+hello:
+  Path("/")
+  -> status(200)
+  -> inlineContent("Bye, World!\n")
+  -> <shunt>;
+
+rest: *
+  -> status(404)
+  -> inlineContent("No route entry\n")
+  -> <shunt>;


### PR DESCRIPTION
## Description

Add a distroless variant of the `skipper0.18` example.

## Changes

- Add the `skipper0.18-distroless` example.
- Use `scratch` as the root filesystem.
- Use the `skipper:0.18` Unikraft runtime.
- Add the Skipper route configuration and `Kraftfile`.
- Add a README with build, run, and testing instructions.
- Add a GitHub Actions workflow to build, scan, and test the example.

## Testing

The example was tested successfully with KraftKit and QEMU.

The GitHub Actions workflow also passes successfully and validates:

- `GET /` returns HTTP 200 with `Bye, World!`.
- `GET /test` returns HTTP 404 with `No route entry`.