### PR TITLE
feat(examples): Add httpserver Perl5.38 base distroless

### DIFF
--- a/.github/workflows/test-httpserver-perl5.38-base-distroless.yaml
+++ b/.github/workflows/test-httpserver-perl5.38-base-distroless.yaml
@@ -1,0 +1,89 @@
+name: Test Perl 5.38 HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-perl5.38-base-distroless/**"
+      - ".github/workflows/test-httpserver-perl5.38-base-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/httpserver-perl5.38-base-distroless/**"
+      - ".github/workflows/test-httpserver-perl5.38-base-distroless.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit (Version Pinned & Verified)
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+
+          awk -v f="kraft_${KRAFT_VERSION}_linux_amd64.tar.gz" '($2==f)||($2=="*"f){print}' "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-perl5.38-base-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/httpserver-perl5.38-base-distroless
+        run: |
+          du -sh .unikraft/build/initramfs-x86_64.cpio
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/httpserver-perl5.38-base-distroless
+        run: docker build --pull -t httpserver-perl5.38-base-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          image-ref: "httpserver-perl5.38-base-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/httpserver-perl5.38-base-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run Unikernel in Background
+        working-directory: examples/httpserver-perl5.38-base-distroless
+        run: kraft run -d --rm -p 8080:8080 --plat qemu --arch x86_64 -M 256M --name perl-test .
+
+      - name: Test Network Connectivity
+        run: |
+          sleep 5
+          curl -s localhost:8080 | grep "Bye, World!"
+
+      - name: Cleanup
+        if: always()
+        run: kraft rm --force perl-test || true

--- a/examples/httpserver-perl5.38-base-distroless/.dockerignore
+++ b/examples/httpserver-perl5.38-base-distroless/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-perl5.38-base-distroless/.gitignore
+++ b/examples/httpserver-perl5.38-base-distroless/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-perl5.38-base-distroless/.trivyignore
+++ b/examples/httpserver-perl5.38-base-distroless/.trivyignore
@@ -1,0 +1,3 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30

--- a/examples/httpserver-perl5.38-base-distroless/Dockerfile
+++ b/examples/httpserver-perl5.38-base-distroless/Dockerfile
@@ -1,0 +1,13 @@
+FROM perl:5.38.0-bookworm AS build
+
+RUN set -xe ; \
+  cpanm HTTP::Daemon
+
+FROM gcr.io/distroless/cc-debian12@sha256:e5d81ddde149641e2a9ba55be4545bc125c67de07508b03ba4c22e6eb0ded5aa
+
+COPY --from=build /usr/local/bin/perl /usr/bin/perl
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/lib/perl5/5.38.0/x86_64-linux-gnu/CORE/libperl.so /usr/local/lib/perl5/5.38.0/x86_64-linux-gnu/CORE/libperl.so
+COPY --from=build /lib/x86_64-linux-gnu/libcrypt.so.1 /lib/x86_64-linux-gnu/libcrypt.so.1
+
+COPY ./server.pl /usr/src/server.pl

--- a/examples/httpserver-perl5.38-base-distroless/Kraftfile
+++ b/examples/httpserver-perl5.38-base-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-perl5.38-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/perl", "/usr/src/server.pl"]

--- a/examples/httpserver-perl5.38-base-distroless/README.md
+++ b/examples/httpserver-perl5.38-base-distroless/README.md
@@ -1,0 +1,60 @@
+# Perl 5.38 Web Server - Distroless
+
+This directory contains a [Perl](https://www.perl.org/) web server running on Unikraft using the gcr.io/distroless/cc-debian12 base image. This minimal environment lacks a shell and unnecessary system utilities, significantly reducing the attack surface.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 256M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+If the `-M` argument (memory allocation) is left out, it defaults to 64M. For this specific image, leaving it out will cause a boot failure (e.g., `Failed to mmap the phdr`) because the virtual machine runs out of memory while unpacking the filesystem in RAM. Explicitly setting it to `-M 256M` provides enough memory and ensures the unikernel boots successfully.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, open a new terminal and use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME             KERNEL                          ARGS                               CREATED          STATUS   MEM   PORTS                   PLAT
+relaxed_titan    oci://unikraft.org/base:latest  /usr/bin/perl /usr/src/server.pl   42 seconds ago   running  244M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `relaxed_titan`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm relaxed_titan
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-perl5.38-base-distroless/server.pl
+++ b/examples/httpserver-perl5.38-base-distroless/server.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+
+use HTTP::Daemon;
+use HTTP::Status;
+use HTTP::Response;
+
+my $daemon = HTTP::Daemon->new(
+	LocalAddr => '0.0.0.0',
+	LocalPort => 8080,
+) or die;
+
+while (my $client_connection = $daemon->accept) {
+	my $request = $client_connection->get_request;
+	my $response = HTTP::Response->new(200);
+	$response->content("Bye, World!\n");
+	$client_connection->send_response($response);
+}


### PR DESCRIPTION
## Description

Added a Perl 5.38 HTTP Server example using the distroless container image `cc-debian12`, which provides a minimal environment with sufficient dependencies. This example uses a multi-stage build to install `HTTP::Daemon` via `cpanm` and selectively copy the required Perl executable, standard libraries, `libperl.so`, and `libcrypt.so.1`.

The `README.md` file contains instructions for building and running the example manually.

## Automated Testing

The second commit of this PR contains a three-stage workflow to build and test this example via GitHub Actions:

1. Measuring the rootfs size (resulting in 82MB)
2. Scanning for vulnerabilities using Trivy
3. Validating the web application operations using `curl` and matching the "Bye, World!" message

## Note on Vulnerability Scanning

Trivy scans are configured to pass by explicitly ignoring `CVE-2026-14456` (libssl3) via `.trivyignore`. This vulnerability affects OpenSSL QUIC servers, a feature that this simple application does not implement or utilize. Furthermore, there is currently no official upstream Debian fix available for the base image (exception expires on 2026-11-30). This exception and the non-clean base state are explicitly acknowledged here.