### PR TITLE
feat(examples): Add httpserver-rust1.75-distroless example

### DIFF
--- a/.github/workflows/test-httpserver-rust-distroless.yml
+++ b/.github/workflows/test-httpserver-rust-distroless.yml
@@ -1,0 +1,117 @@
+name: Test Rust HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-rust1.75-distroless/**"
+      - ".github/workflows/test-httpserver-rust-distroless.yml"
+  pull_request:
+    paths:
+      - "examples/httpserver-rust1.75-distroless/**"
+      - ".github/workflows/test-httpserver-rust-distroless.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Install KraftKit (Version Pinned & Verified)
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+
+          grep " kraft_${KRAFT_VERSION}_linux_amd64.tar.gz\$" "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-rust1.75-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/httpserver-rust1.75-distroless
+        run: |
+          set -euo pipefail
+
+          mapfile -t cpio_files < <(find .unikraft/build/ -type f -name "*.cpio")
+          if [ "${#cpio_files[@]}" -eq 0 ]; then
+            echo "No .cpio artifacts found under .unikraft/build/" >&2
+            exit 1
+          fi
+
+          du -h "${cpio_files[@]}"
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/httpserver-rust1.75-distroless
+        run: docker build --pull -t httpserver-rust1.75-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          scan-ref: "httpserver-rust1.75-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/httpserver-rust1.75-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run Unikernel in Background
+        working-directory: examples/httpserver-rust1.75-distroless
+        run: kraft run -d --plat qemu --arch x86_64 -M 128M -p 8080:8080 --name httpserver-test .
+
+      - name: Test Network Connectivity
+        run: |
+          set -euo pipefail
+
+          for i in $(seq 1 15); do
+            if curl -s --max-time 2 http://127.0.0.1:8080/ | grep -q "Bye, World!"; then
+              echo "Server responded correctly."
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Server did not respond as expected within 15s" >&2
+          exit 1
+
+      - name: Dump Unikernel Logs on Failure
+        if: failure()
+        working-directory: examples/httpserver-rust1.75-distroless
+        run: kraft ps -a; kraft logs httpserver-test || true
+
+      - name: Cleanup
+        if: always()
+        run: kraft rm --force httpserver-test || true

--- a/examples/httpserver-rust1.75-distroless/.trivyignore
+++ b/examples/httpserver-rust1.75-distroless/.trivyignore
@@ -1,0 +1,4 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30
+

--- a/examples/httpserver-rust1.75-distroless/Dockerfile
+++ b/examples/httpserver-rust1.75-distroless/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.75.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./server.rs /src/server.rs
+
+RUN set -xe; \
+    rustc -O -o /server /src/server.rs
+
+FROM gcr.io/distroless/cc-debian12@sha256:e5d81ddde149641e2a9ba55be4545bc125c67de07508b03ba4c22e6eb0ded5aa
+
+COPY --from=build /server /server
+

--- a/examples/httpserver-rust1.75-distroless/Kraftfile
+++ b/examples/httpserver-rust1.75-distroless/Kraftfile
@@ -1,0 +1,10 @@
+spec: v0.6
+
+name: httpserver-rust1.75-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/server"]
+

--- a/examples/httpserver-rust1.75-distroless/README.md
+++ b/examples/httpserver-rust1.75-distroless/README.md
@@ -1,0 +1,72 @@
+# Rust HTTP Web Server - Distroless
+
+This directory contains a [Rust](https://www.rust-lang.org/) HTTP server running on Unikraft.
+It utilizes a Distroless container image (`gcr.io/distroless/cc-debian12`) to provide a minimal, secure root filesystem containing only the required runtime dependencies.
+
+## Distroless Build
+
+For this example's needs, the chosen distroless image provides:
+
+- The dynamic linker `ld-linux-x86-64`
+- The libraries `libc` and `libgcc_s`
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 128M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME          KERNEL                          ARGS     CREATED         STATUS   MEM   PORTS                   PLAT
+blissful_moe  oci://unikraft.org/base:latest  /server  19 seconds ago  running  128M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `blissful_moe`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm blissful_moe
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 256M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-rust1.75-distroless/server.rs
+++ b/examples/httpserver-rust1.75-distroless/server.rs
@@ -1,0 +1,51 @@
+// https://gist.github.com/mjohnsullivan/e5182707caf0a9dbdf2d
+// Updated example from http://rosettacode.org/wiki/Hello_world/Web_server#Rust
+// to work with Rust 1.0 beta
+
+use std::net::{TcpStream, TcpListener};
+use std::io::{Read, Write};
+use std::thread;
+
+
+fn handle_read(mut stream: &TcpStream) {
+    let mut buf = [0u8 ;4096];
+    match stream.read(&mut buf) {
+        Ok(_) => {
+            let req_str = String::from_utf8_lossy(&buf);
+            println!("{}", req_str);
+        },
+        Err(e) => println!("Unable to read stream: {}", e),
+    }
+}
+
+fn handle_write(mut stream: TcpStream) {
+    let response = b"HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\nBye, World!\r\n";
+    match stream.write(response) {
+        Ok(_) => println!("Response sent"),
+        Err(e) => println!("Failed sending response: {}", e),
+    }
+}
+
+fn handle_client(stream: TcpStream) {
+    handle_read(&stream);
+    handle_write(stream);
+}
+
+fn main() {
+    let listener = TcpListener::bind("0.0.0.0:8080").unwrap();
+    println!("Listening for connections on port {}", 8080);
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                thread::spawn(|| {
+                    handle_client(stream)
+                });
+            }
+            Err(e) => {
+                println!("Unable to connect: {}", e);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Description

Added a Rust HTTP server example using the distroless container image `gcr.io/distroless/cc-debian12`, which is compatible with `bookworm` and provides sufficient dependencies. This example is based on the [existing one](https://github.com/unikraft/catalog/tree/main/examples/httpserver-rust1.75) in the catalog, enhancing the container build via distroless.

The `README.md` file contains instructions for building and running the example manually, as well as the list of dependencies that are covered by the chosen distroless image:

- The dynamic linker `ld-linux-x86-64`
- The libraries `libc` and `libgcc_s`

## Automated Testing

The second commit of this PR contains a three-stage workflow to build and test this example via Github Actions:

1. Measuring the `rootfs` size (resulting in *28MB*)
2. Scanning for vulnerabilities using Trivy (one found, but not relevant, see `.trivyignore` for more)
3. Running in the background and testing connectivity using `curl`