### PR TITLE
feat(examples): Add httpserver-boost1.74-cpp13.2-distroless example

### DIFF
--- a/.github/workflows/test-httpserver-boost1.74-cpp13.2-distroless.yml
+++ b/.github/workflows/test-httpserver-boost1.74-cpp13.2-distroless.yml
@@ -1,0 +1,117 @@
+name: Test C++ Boost HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-boost1.74-cpp13.2-distroless/**"
+      - ".github/workflows/test-httpserver-boost1.74-cpp13.2-distroless.yml"
+  pull_request:
+    paths:
+      - "examples/httpserver-boost1.74-cpp13.2-distroless/**"
+      - ".github/workflows/test-httpserver-boost1.74-cpp13.2-distroless.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Install KraftKit (Version Pinned & Verified)
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+
+          grep " kraft_${KRAFT_VERSION}_linux_amd64.tar.gz\$" "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-boost1.74-cpp13.2-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/httpserver-boost1.74-cpp13.2-distroless
+        run: |
+          set -euo pipefail
+
+          mapfile -t cpio_files < <(find .unikraft/build/ -type f -name "*.cpio")
+          if [ "${#cpio_files[@]}" -eq 0 ]; then
+            echo "No .cpio artifacts found under .unikraft/build/" >&2
+            exit 1
+          fi
+
+          du -h "${cpio_files[@]}"
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/httpserver-boost1.74-cpp13.2-distroless
+        run: docker build --pull -t httpserver-boost1.74-cpp13.2-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          scan-ref: "httpserver-boost1.74-cpp13.2-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/httpserver-boost1.74-cpp13.2-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run Unikernel in Background
+        working-directory: examples/httpserver-boost1.74-cpp13.2-distroless
+        run: kraft run -d --plat qemu --arch x86_64 -M 128M -p 8080:8080 --name boost-test .
+
+      - name: Test Network Connectivity
+        run: |
+          set -euo pipefail
+
+          for i in $(seq 1 15); do
+            if curl -s --max-time 2 http://127.0.0.1:8080/ | grep -q "Hello, World!"; then
+              echo "Server responded correctly."
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Server did not respond as expected within 15s" >&2
+          exit 1
+
+      - name: Dump Unikernel Logs on Failure
+        if: failure()
+        working-directory: examples/httpserver-boost1.74-cpp13.2-distroless
+        run: kraft ps -a; kraft logs boost-test || true
+
+      - name: Cleanup
+        if: always()
+        run: kraft rm --force boost-test || true

--- a/examples/httpserver-boost1.74-cpp13.2-distroless/.dockerignore
+++ b/examples/httpserver-boost1.74-cpp13.2-distroless/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-boost1.74-cpp13.2-distroless/.gitignore
+++ b/examples/httpserver-boost1.74-cpp13.2-distroless/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-boost1.74-cpp13.2-distroless/.trivyignore
+++ b/examples/httpserver-boost1.74-cpp13.2-distroless/.trivyignore
@@ -1,0 +1,4 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30
+

--- a/examples/httpserver-boost1.74-cpp13.2-distroless/Dockerfile
+++ b/examples/httpserver-boost1.74-cpp13.2-distroless/Dockerfile
@@ -1,0 +1,27 @@
+FROM --platform=linux/x86_64 debian:bookworm AS build
+
+RUN set -xe ; \
+	apt -yqq update ; \
+	apt -yqq install build-essential ; \
+	apt -yqq install libboost-all-dev
+
+WORKDIR /src
+
+COPY ./http_server.cpp /src/http_server.cpp
+
+RUN set -xe; \
+    g++ \
+        -O3 \
+	      -Wall -Wextra \
+	      -fPIC -pie \
+	      -o /http_server http_server.cpp \
+	      -lboost_system -lboost_thread -lpthread
+
+FROM gcr.io/distroless/cc-debian12@sha256:e5d81ddde149641e2a9ba55be4545bc125c67de07508b03ba4c22e6eb0ded5aa
+
+# Boost dependency
+COPY --from=build /lib/x86_64-linux-gnu/libboost_thread.so.1.74.0 /lib/x86_64-linux-gnu/libboost_thread.so.1.74.0
+
+# C++ HTTP server
+COPY --from=build /http_server /http_server
+

--- a/examples/httpserver-boost1.74-cpp13.2-distroless/Kraftfile
+++ b/examples/httpserver-boost1.74-cpp13.2-distroless/Kraftfile
@@ -1,0 +1,10 @@
+spec: v0.6
+
+name: httpserver-boost1.74-g++13.2-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/http_server"]
+

--- a/examples/httpserver-boost1.74-cpp13.2-distroless/README.md
+++ b/examples/httpserver-boost1.74-cpp13.2-distroless/README.md
@@ -1,0 +1,74 @@
+# C++ Boost HTTP Web Server - Distroless
+
+This directory contains a C++ [Boost](https://www.boost.org/) web server running on Unikraft.
+It utilizes a Distroless container image (`gcr.io/distroless/cc-debian12`) to provide a minimal, secure root filesystem containing only the required runtime dependencies.
+
+## Distroless Build
+
+For this example's needs, the chosen distroless image provides:
+
+- The dynamic linker `ld-linux-x86-64`
+- The libraries `libm`, `libc`, `libgcc_s` and `libstdc++`
+
+The remaining dependency `libboost_thread` still needs to be copied manually on top of that (see `Dockerfile`).
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 128M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Hello, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME              KERNEL                          ARGS          CREATED        STATUS   MEM   PORTS                   PLAT
+stupefied_jumoke  oci://unikraft.org/base:latest  /http_server  4 seconds ago  running  128M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `stupefied_jumoke`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm stupefied_jumoke
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run -p 8080:8080 --plat qemu --arch x86_64 -M 256M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-boost1.74-cpp13.2-distroless/http_server.cpp
+++ b/examples/httpserver-boost1.74-cpp13.2-distroless/http_server.cpp
@@ -1,0 +1,116 @@
+/**
+ *  Compile with: g++ async_http_server.cpp -o async_http_server -lboost_system
+ * -lboost_thread -lpthread
+ *
+ *  https://gist.github.com/danilogr/990efa4ab3b5bce29b883b931ac55507
+ */
+
+#include <boost/asio.hpp>
+#include <boost/enable_shared_from_this.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/thread.hpp>
+#include <ctime>
+#include <functional>
+#include <iostream>
+#include <istream>
+#include <ostream>
+#include <string>
+
+using boost::asio::ip::tcp;
+
+class HttpServer; // forward declaration
+
+class Request : public boost::enable_shared_from_this<Request> {
+  // member variables
+  HttpServer &server;
+  boost::asio::streambuf request;
+  boost::asio::streambuf response;
+
+  void afterRead(const boost::system::error_code &ec,
+                 std::size_t bytes_transferred) {
+    // done reading, writes answer (yes, we ignore the request);
+    std::ostream res_stream(&response);
+
+    boost::system::error_code err;
+    res_stream << "HTTP/1.0 200 OK\r\n"
+               << "Content-Type: text/html; charset=UTF-8\r\n"
+               << "Content-Length: 14\r\n"
+               << "\r\n"
+               << "Hello, World!\n"
+               << "\r\n";
+    boost::asio::async_write(*socket, response,
+                             boost::bind(&Request::afterWrite,
+                                         shared_from_this(), err,
+                                         bytes_transferred));
+  }
+
+  void afterWrite(const boost::system::error_code &ec,
+                  std::size_t bytes_transferred) {
+    // done writing, closing connection
+    socket->close();
+  }
+
+public:
+  boost::shared_ptr<tcp::socket> socket;
+  Request(HttpServer &server);
+  void answer() {
+    if (!socket)
+      return;
+
+    // reads request till the end
+    boost::system::error_code err;
+    boost::asio::async_read_until(
+        *socket, request, "\r\n\r\n",
+        boost::bind(&Request::afterRead, shared_from_this(), err, 0));
+  }
+};
+
+class HttpServer {
+public:
+  HttpServer(unsigned int port)
+      : acceptor(io_service, tcp::endpoint(tcp::v4(), port)) {}
+  ~HttpServer() {
+    if (sThread)
+      sThread->join();
+  }
+
+  void Run() {
+    sThread.reset(
+        new boost::thread(boost::bind(&HttpServer::thread_main, this)));
+  }
+
+  boost::asio::io_service io_service;
+
+private:
+  tcp::acceptor acceptor;
+  boost::shared_ptr<boost::thread> sThread;
+
+  void thread_main() {
+    // adds some work to the io_service
+    start_accept();
+    io_service.run();
+  }
+  void start_accept() {
+    boost::system::error_code err;
+    boost::shared_ptr<Request> req(new Request(*this));
+    acceptor.async_accept(
+        *req->socket, boost::bind(&HttpServer::handle_accept, this, req, err));
+  }
+
+  void handle_accept(boost::shared_ptr<Request> req,
+                     const boost::system::error_code &error) {
+    if (!error) {
+      req->answer();
+    }
+    start_accept();
+  }
+};
+
+Request::Request(HttpServer &server) : server(server) {
+  socket.reset(new tcp::socket(server.io_service));
+}
+
+int main() {
+  HttpServer server(8080);
+  server.Run();
+}


### PR DESCRIPTION
## Description

Added a C++ Boost1.74 server example using the distroless container image `gcr.io/distroless/cc-debian12`, which is compatible with `bookworm` and provides sufficient dependencies. This example is based on the [existing one](https://github.com/unikraft/catalog/tree/main/examples/httpserver-boost1.74-g++13.2) in the catalog, enhancing the container build via distroless.

The `README.md` file contains instructions for building and running the example manually, as well as the list of dependencies that are covered by the chosen distroless image:

- The dynamic linker `ld-linux-x86-64`
- The libraries `libm`, `libc`, `libgcc_s` and `libstdc++`

The remaining dependency `libboost_thread` still needed to be copied manually on top of that (see `Dockerfile`).

## Automated Testing

The second commit of this PR contains a three-stage workflow to build and test this example via Github Actions:

1. Measuring the `rootfs` size (resulting in *24MB*)
2. Scanning for vulnerabilities using Trivy (one found, but not relevant, see `.trivyignore` for more)
3. Running in the background and testing connectivity using `curl`

## Notes

The workflow YAML file had issues parsing `g++` in directory names. Instead of working around with some odd regex expressions, I preferred to slightly change the name to `cpp`, which I would argue is equally recognisable.