### PR TITLE
feat(examples): Add memcached1.6-base-distroless example

### DIFF
--- a/.github/workflows/test-memcached1.6-base-distroless.yaml
+++ b/.github/workflows/test-memcached1.6-base-distroless.yaml
@@ -1,0 +1,221 @@
+name: Test Memcached 1.6 Base Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/memcached1.6-base-distroless/**"
+      - ".github/workflows/test-memcached1.6-base-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/memcached1.6-base-distroless/**"
+      - ".github/workflows/test-memcached1.6-base-distroless.yaml"
+
+jobs:
+  build-test:
+    name: Build and test Memcached 1.6 Base Distroless
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          set -eux
+
+          sudo apt-get update
+          sudo apt-get install -y \
+            curl \
+            ca-certificates \
+            netcat-openbsd \
+            qemu-system-x86 \
+            qemu-utils
+
+      - name: Install KraftKit
+        run: |
+          set -eux
+
+          curl -sSfL https://get.kraftkit.sh | \
+            sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Verify KraftKit
+        run: |
+          set -eux
+
+          command -v kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/memcached1.6-base-distroless
+        run: |
+          set -eux
+
+          kraft build \
+            --plat qemu \
+            --arch x86_64 \
+            .
+
+      - name: Measure rootfs size
+        working-directory: examples/memcached1.6-base-distroless
+        run: |
+          echo "===== Build directory ====="
+          du -sh .unikraft/build/ || true
+
+          echo "===== Image/rootfs files ====="
+          find .unikraft/build/ -type f \
+            \( -name "*.img" -o -name "*.cpio" \) \
+            -exec du -h {} + || true
+
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: examples/memcached1.6-base-distroless
+          format: table
+          exit-code: "0"
+          severity: CRITICAL,HIGH
+
+      - name: Inspect build artifacts
+        working-directory: examples/memcached1.6-base-distroless
+        run: |
+          set -eux
+
+          echo "===== .unikraft/build ====="
+          find .unikraft/build -maxdepth 3 -type f -print | sort
+
+          echo "===== Build directory size ====="
+          du -sh .unikraft/build
+
+      - name: Enable KVM
+        run: |
+          set -eux
+
+          sudo chmod 666 /dev/kvm
+
+      - name: Run Unikernel and test Memcached
+        working-directory: examples/memcached1.6-base-distroless
+        run: |
+          set -e
+
+          rm -f kraft.log
+
+          echo "===== Kraft version ====="
+          kraft version
+
+          echo "===== Starting Memcached Unikernel ====="
+
+          kraft run \
+            --rm \
+            -p 11211:11211 \
+            --plat qemu \
+            --arch x86_64 \
+            -M 256M \
+            . > kraft.log 2>&1 &
+
+          KRAFT_PID=$!
+
+          cleanup() {
+            echo "===== Stopping Unikraft ====="
+
+            if kill -0 "$KRAFT_PID" 2>/dev/null; then
+              kill "$KRAFT_PID" 2>/dev/null || true
+              sleep 2
+            fi
+
+            wait "$KRAFT_PID" 2>/dev/null || true
+          }
+
+          trap cleanup EXIT
+
+          echo "===== Waiting for Memcached ====="
+
+          VERSION_OUTPUT=""
+
+          for i in $(seq 1 90); do
+            if ! kill -0 "$KRAFT_PID" 2>/dev/null; then
+              echo "ERROR: Unikraft exited before Memcached became ready."
+              echo "===== Kraft log ====="
+              cat kraft.log || true
+              exit 1
+            fi
+
+            VERSION_OUTPUT="$(
+              printf 'version\r\n' |
+                nc -w 3 127.0.0.1 11211 2>/dev/null || true
+            )"
+
+            if echo "$VERSION_OUTPUT" | tr -d '\r' | grep -Fq "VERSION 1.6.23"; then
+              echo "Memcached is ready."
+              break
+            fi
+
+            sleep 1
+          done
+
+          echo "===== Kraft log ====="
+          cat kraft.log || true
+
+          echo "===== Memcached version ====="
+          printf '%s\n' "$VERSION_OUTPUT"
+
+          VERSION_CLEAN="$(
+            printf '%s\n' "$VERSION_OUTPUT" |
+              tr -d '\r'
+          )"
+
+          if ! printf '%s\n' "$VERSION_CLEAN" | grep -Fq "VERSION 1.6.23"; then
+            echo "ERROR: Memcached did not return the expected version."
+            echo "Expected: VERSION 1.6.23"
+            echo "Received:"
+            printf '%s\n' "$VERSION_CLEAN"
+            exit 1
+          fi
+
+          echo "Memcached version validated successfully."
+
+          echo "===== Memcached functional test ====="
+
+          RESPONSE="$(
+            printf 'set test 0 0 5\r\nhello\r\nget test\r\nquit\r\n' |
+              nc -w 5 127.0.0.1 11211
+          )"
+
+          printf '%s\n' "$RESPONSE"
+
+          echo "===== Normalized Memcached response ====="
+
+          RESPONSE_CLEAN="$(
+            printf '%s\n' "$RESPONSE" |
+              tr -d '\r'
+          )"
+
+          printf '%s\n' "$RESPONSE_CLEAN"
+
+          echo "===== Validating Memcached response ====="
+
+          if ! printf '%s\n' "$RESPONSE_CLEAN" | grep -Fxq "STORED"; then
+            echo "ERROR: Missing STORED response."
+            exit 1
+          fi
+
+          if ! printf '%s\n' "$RESPONSE_CLEAN" | grep -Fxq "VALUE test 0 5"; then
+            echo "ERROR: Missing VALUE response."
+            exit 1
+          fi
+
+          if ! printf '%s\n' "$RESPONSE_CLEAN" | grep -Fxq "hello"; then
+            echo "ERROR: Missing stored value."
+            exit 1
+          fi
+
+          if ! printf '%s\n' "$RESPONSE_CLEAN" | grep -Fxq "END"; then
+            echo "ERROR: Missing END response."
+            exit 1
+          fi
+
+          echo "Memcached set/get test passed."
+
+          echo "========================================="
+          echo " Memcached 1.6.23 test PASSED"
+          echo "========================================="

--- a/examples/memcached1.6-base-distroless/.dockerignore
+++ b/examples/memcached1.6-base-distroless/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/memcached1.6-base-distroless/.gitignore
+++ b/examples/memcached1.6-base-distroless/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/memcached1.6-base-distroless/Dockerfile
+++ b/examples/memcached1.6-base-distroless/Dockerfile
@@ -1,0 +1,35 @@
+FROM memcached:1.6.23-bookworm AS build
+
+FROM alpine:3 AS sys
+
+RUN set -xe; \
+    mkdir -p /target/etc; \
+    mkdir -p /blank; \
+    apk --no-cache add \
+        ca-certificates \
+        tzdata \
+        ; \
+    update-ca-certificates; \
+    ln -sf ../usr/share/zoneinfo/Etc/UTC /target/etc/localtime; \
+    echo "Etc/UTC" > /target/etc/timezone
+
+FROM scratch
+
+COPY --from=sys /target/etc /etc
+COPY --from=sys /usr/share/zoneinfo/Etc/UTC /usr/share/zoneinfo/Etc/UTC
+COPY --from=sys /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=sys /blank /tmp
+
+# Binary executable
+COPY --from=build /usr/local/bin/memcached /usr/bin/memcached
+
+# System libraries
+COPY --from=build /lib/x86_64-linux-gnu/libssl.so.3 /lib/x86_64-linux-gnu/libssl.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libevent-2.1.so.7 /lib/x86_64-linux-gnu/libevent-2.1.so.7
+COPY --from=build /lib/x86_64-linux-gnu/libsasl2.so.2 /lib/x86_64-linux-gnu/libsasl2.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+# Configuration
+COPY --from=build /etc/passwd /etc/passwd

--- a/examples/memcached1.6-base-distroless/Kraftfile
+++ b/examples/memcached1.6-base-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: memcached1.6-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/memcached", "-u", "root"]

--- a/examples/memcached1.6-base-distroless/README.md
+++ b/examples/memcached1.6-base-distroless/README.md
@@ -1,0 +1,81 @@
+# Memcached 1.6 Distroless
+
+This example demonstrates how to run [Memcached](https://memcached.org), an in-memory key-value store for small chunks of arbitrary data, on Unikraft using a minimal distroless root filesystem.
+
+The root filesystem is built from `scratch` and contains only the Memcached binary, the required system libraries, certificates, timezone data, and configuration files needed to run the application.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 11211:11211 --plat qemu --arch x86_64 -M 256M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `11211` and wait for connections.
+
+To test the Memcached server, use `nc`:
+
+```bash
+printf "set test 0 0 5\r\nhello\r\nget test\r\nquit\r\n" | nc 127.0.0.1 11211
+```
+
+You should see:
+
+```text
+STORED
+VALUE test 0 5
+hello
+END
+```
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+For example:
+
+```text
+NAME             KERNEL                            ARGS                        CREATED         STATUS   MEM   PORTS                     PLAT
+
+admiring_pankun  oci://unikraft.org/memcached:1.6  /usr/bin/memcached -u root  54 seconds ago  running  244M  0.0.0.0:11211->11211/tcp  qemu/x86_64
+```
+
+The instance name is `admiring_pankun`.
+
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm admiring_pankun
+```
+
+Note that depending on how you modify this example, your instance **may** need more memory to run.
+
+To increase the allocated memory, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 11211:11211 --plat qemu --arch x86_64 -M 512M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+
+Read more about how to start `kraft` without `sudo` at https://unikraft.org/sudoless.
+
+## Learn More
+
+* [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+* [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)


### PR DESCRIPTION
## Description

Add a distroless variant of the `memcached1.6-base` example.

## Changes

- Add the `memcached1.6-base-distroless` example.
- Use `memcached:1.6.23-bookworm` as the build image.
- Use `scratch` as the final root filesystem.
- Copy only the required runtime libraries and configuration files.
- Use the `base:latest` Unikraft runtime.
- Add the required `Kraftfile` configuration.
- Add a README with build, run, and testing instructions.
- Add a GitHub Actions workflow to build, scan, and test the example.

## Testing

The example was tested successfully with Docker and KraftKit/QEMU.

The GitHub Actions workflow also passes successfully and validates:

- Memcached starts successfully on port `11211`.
- Memcached reports version `1.6.23`.
- `set/get` functionality works correctly.
- The expected `STORED`, `VALUE`, `hello`, and `END` responses are returned.