### PR TITLE
feat(examples): Add caddy2.7-go1.21-base-distroless example

### DIFF
--- a/.github/workflows/test-caddy2.7-go1.21-base-distroless.yaml
+++ b/.github/workflows/test-caddy2.7-go1.21-base-distroless.yaml
@@ -1,0 +1,197 @@
+name: Test Caddy 2.7 Go 1.21 Base Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/caddy2.7-go1.21-base-distroless/**"
+      - ".github/workflows/test-caddy2.7-go1.21-base-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/caddy2.7-go1.21-base-distroless/**"
+      - ".github/workflows/test-caddy2.7-go1.21-base-distroless.yaml"
+
+jobs:
+  build-test:
+    name: Build and test Caddy 2.7 Go 1.21 Base Distroless
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          set -eux
+
+          sudo apt-get update
+
+          sudo apt-get install -y \
+            curl \
+            ca-certificates \
+            qemu-system-x86 \
+            qemu-utils
+
+      - name: Install KraftKit
+        run: |
+          set -eux
+
+          curl -sSfL https://get.kraftkit.sh | \
+            sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Verify KraftKit
+        run: |
+          set -eux
+
+          command -v kraft
+          kraft version
+
+      - name: Build Caddy Unikernel
+        working-directory: examples/caddy2.7-go1.21-base-distroless
+        run: |
+          set -eux
+
+          echo "===== Building Caddy Unikernel ====="
+
+          kraft build \
+            --plat qemu \
+            --arch x86_64 \
+            .
+
+          echo "===== Build completed ====="
+
+          test -d .unikraft/build
+
+          echo "===== Build contents ====="
+          find .unikraft/build -maxdepth 3 -type f -print | sort
+
+      - name: Check rootfs artifact
+        working-directory: examples/caddy2.7-go1.21-base-distroless
+        run: |
+          set -eux
+
+          ROOTFS=".unikraft/build/initramfs-x86_64.cpio"
+
+          if [ ! -f "$ROOTFS" ]; then
+            echo "ERROR: Expected rootfs was not generated:"
+            echo "$ROOTFS"
+            echo
+            echo "Available build artifacts:"
+            find .unikraft/build -type f -print | sort
+            exit 1
+          fi
+
+          echo "Rootfs found:"
+          ls -lh "$ROOTFS"
+
+      - name: Measure rootfs size
+        working-directory: examples/caddy2.7-go1.21-base-distroless
+        run: |
+          echo "===== Build directory ====="
+          du -sh .unikraft/build
+
+          echo "===== Rootfs ====="
+          du -h .unikraft/build/initramfs-x86_64.cpio
+
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: examples/caddy2.7-go1.21-base-distroless
+          format: table
+          exit-code: "0"
+          severity: CRITICAL,HIGH
+
+      - name: Enable KVM
+        run: |
+          set -eux
+
+          sudo chmod 666 /dev/kvm
+
+      - name: Run Caddy Unikernel
+        working-directory: examples/caddy2.7-go1.21-base-distroless
+        run: |
+          set -e
+
+          echo "===== Starting Caddy ====="
+
+          kraft run \
+            --rm \
+            --plat qemu \
+            --arch x86_64 \
+            -M 256M \
+            -p 2015:2015 \
+            . > kraft.log 2>&1 &
+
+          KRAFT_PID=$!
+
+          echo "Kraft PID: $KRAFT_PID"
+
+          cleanup() {
+            echo "===== Cleanup ====="
+
+            if kill -0 "$KRAFT_PID" 2>/dev/null; then
+              kill "$KRAFT_PID" 2>/dev/null || true
+              sleep 2
+            fi
+
+            wait "$KRAFT_PID" 2>/dev/null || true
+          }
+
+          trap cleanup EXIT
+
+          echo "===== Waiting for Caddy HTTP server ====="
+
+          READY=0
+
+          for i in $(seq 1 120); do
+            if ! kill -0 "$KRAFT_PID" 2>/dev/null; then
+              echo "ERROR: Kraft exited unexpectedly."
+
+              echo "===== Kraft log ====="
+              cat kraft.log || true
+
+              exit 1
+            fi
+
+            if curl -fsS \
+              --connect-timeout 2 \
+              --max-time 3 \
+              http://127.0.0.1:2015 \
+              > response.txt 2>/dev/null; then
+
+              READY=1
+              echo "Caddy is ready after ${i}s."
+              break
+            fi
+
+            sleep 1
+          done
+
+          echo "===== Kraft log ====="
+          cat kraft.log || true
+
+          if [ "$READY" -ne 1 ]; then
+            echo "ERROR: Caddy did not become ready."
+
+            echo "===== Final HTTP attempt ====="
+            curl -v \
+              --connect-timeout 2 \
+              --max-time 5 \
+              http://127.0.0.1:2015 || true
+
+            exit 1
+          fi
+
+          echo "===== HTTP response ====="
+          cat response.txt
+
+          echo "===== Validating response ====="
+
+          grep -Fq "Bye, World!" response.txt
+
+          echo "Caddy HTTP response validated successfully."
+
+          echo "========================================="
+          echo " Caddy 2.7.5 test PASSED"
+          echo "========================================="

--- a/examples/caddy2.7-go1.21-base-distroless/.dockerignore
+++ b/examples/caddy2.7-go1.21-base-distroless/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/caddy2.7-go1.21-base-distroless/.gitignore
+++ b/examples/caddy2.7-go1.21-base-distroless/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/caddy2.7-go1.21-base-distroless/Dockerfile
+++ b/examples/caddy2.7-go1.21-base-distroless/Dockerfile
@@ -1,0 +1,53 @@
+FROM golang:1.21.3-bookworm AS build
+
+
+
+ARG CADDY_VERSION=2.7.5
+
+
+
+WORKDIR /caddy
+
+
+
+RUN --mount=type=cache,target=/root/go/pkg/mod \
+
+    --mount=type=cache,target=/root/.cache/go-build \
+
+    set -xe; \
+
+    apt-get update; \
+
+    apt-get install -y --no-install-recommends \
+
+        git \
+
+        ca-certificates; \
+
+    git clone --depth=1 --branch v${CADDY_VERSION} https://github.com/caddyserver/caddy.git /caddy; \
+
+    go build -v \
+
+        -buildmode=pie \
+
+        -ldflags "-linkmode external -extldflags -static-pie" \
+
+        -tags netgo \
+
+        -o /caddy/caddy cmd/caddy/main.go;
+
+
+
+RUN echo "127.0.0.1 localhost" > /tmp/hosts
+
+
+
+FROM scratch
+
+
+
+COPY --from=build /caddy/caddy /usr/bin/caddy
+
+COPY --from=build /tmp/hosts /etc/hosts
+
+COPY ./rootfs /

--- a/examples/caddy2.7-go1.21-base-distroless/Kraftfile
+++ b/examples/caddy2.7-go1.21-base-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: caddy2.7-go1.21-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/examples/caddy2.7-go1.21-base-distroless/README.md
+++ b/examples/caddy2.7-go1.21-base-distroless/README.md
@@ -1,0 +1,66 @@
+# Caddy2.7-go1.21-base-distroless
+
+[Caddy](https://caddyserver.com/) is a web server written in Go.
+
+This example shows how to run Caddy 2.7.5 on Unikraft using a distroless `scratch` root filesystem.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to build and run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 2015:2015 --plat qemu --arch x86_64 -M 256M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `2015` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:2015
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME              KERNEL                        ARGS                                              CREATED        STATUS   MEM   PORTS                   PLAT
+vigilant_michael  oci://unikraft.org/caddy:2.7  /usr/bin/caddy run --config /etc/caddy/Caddyfile  6 seconds ago  running  244M  0.0.0.0:2015->2015/tcp  qemu/x86_64
+```
+
+The instance name is `vigilant_michael`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm vigilant_michael
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 2015:2015 --plat qemu --arch x86_64 -M 512M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/caddy2.7-go1.21-base-distroless/rootfs/etc/caddy/Caddyfile
+++ b/examples/caddy2.7-go1.21-base-distroless/rootfs/etc/caddy/Caddyfile
@@ -1,0 +1,9 @@
+:2015
+
+root * /var/www
+
+encode gzip
+
+templates
+
+file_server

--- a/examples/caddy2.7-go1.21-base-distroless/rootfs/var/www/index.html
+++ b/examples/caddy2.7-go1.21-base-distroless/rootfs/var/www/index.html
@@ -1,0 +1,1 @@
+Bye, World!


### PR DESCRIPTION
## Description

Add a distroless variant of the `caddy2.7-go1.21-base` example.

## Changes

- Add the `caddy2.7-go1.21-base-distroless` example.
- Build Caddy 2.7.5 from source using Go 1.21.
- Build the Caddy binary as a static PIE executable.
- Use `scratch` as the final root filesystem.
- Use the `base:latest` Unikraft runtime.
- Add the required Caddy configuration and `Kraftfile`.
- Add a README with build, run, and testing instructions.
- Add a GitHub Actions workflow to build, scan, and test the example.

## Testing

The example was tested successfully with Docker and KraftKit/QEMU.

The GitHub Actions workflow also passes successfully and validates:

- Caddy starts successfully on port `2015`.
- The HTTP server responds successfully.
- The expected `Bye, World!` response is returned.