### PR TITLE
feat(examples): Add httpserver-nodejs18-base-distroless example

### DIFF
--- a/.github/workflows/test-httpserver-nodejs18-distroless.yaml
+++ b/.github/workflows/test-httpserver-nodejs18-distroless.yaml
@@ -1,0 +1,89 @@
+name: Test Node.js 18 HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-nodejs18-base-distroless/**"
+      - ".github/workflows/test-httpserver-nodejs18-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/httpserver-nodejs18-base-distroless/**"
+      - ".github/workflows/test-httpserver-nodejs18-distroless.yaml"
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        run: curl -sSfL https://get.kraftkit.sh | sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-nodejs18-base-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/httpserver-nodejs18-base-distroless
+        run: |
+          du -sh .unikraft/build/ || true
+          find .unikraft/build/ -type f -name "*.img" -exec du -h {} + || true
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          scan-ref: "examples/httpserver-nodejs18-base-distroless"
+          format: "table"
+          exit-code: "0"
+          severity: "CRITICAL,HIGH"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          sudo chmod 666 /dev/kvm
+
+      - name: Run and Validate Output
+        working-directory: examples/httpserver-nodejs18-base-distroless
+        run: |
+          kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 512M > kraft.log 2>&1 &
+          KRAFT_PID=$!
+
+          echo "Waiting for HTTP server..."
+
+          for i in {1..30}; do
+            if curl -fsS http://localhost:8080 > response.txt 2>/dev/null; then
+              break
+            fi
+
+            if ! kill -0 $KRAFT_PID 2>/dev/null; then
+              echo "Kraft process exited unexpectedly."
+              cat kraft.log
+              exit 1
+            fi
+
+            sleep 2
+          done
+
+          cat kraft.log
+
+          if [ ! -f response.txt ]; then
+            echo "HTTP server did not become available."
+            exit 1
+          fi
+
+          if ! grep -q "Bye, World!" response.txt; then
+            echo "Unexpected HTTP response:"
+            cat response.txt
+            exit 1
+          fi
+
+          echo "HTTP response validated successfully:"
+          cat response.txt
+
+          kill $KRAFT_PID 2>/dev/null || true
+          wait $KRAFT_PID 2>/dev/null || true

--- a/examples/httpserver-nodejs18-base-distroless/Dockerfile
+++ b/examples/httpserver-nodejs18-base-distroless/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:18-alpine AS node
+
+FROM gcr.io/distroless/base-debian12
+
+# Node binary
+COPY --from=node /usr/local/bin/node /usr/bin/node
+
+# Node runtime libraries
+COPY --from=node /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=node /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=node /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+
+# Node HTTP server
+COPY ./src/server.js /usr/src/server.js
+
+CMD ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/httpserver-nodejs18-base-distroless/Kraftfile
+++ b/examples/httpserver-nodejs18-base-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-nodejs18-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/httpserver-nodejs18-base-distroless/README.md
+++ b/examples/httpserver-nodejs18-base-distroless/README.md
@@ -1,0 +1,64 @@
+# NodeJS 18 HTTP Web Server
+
+This directory contains a [Node](https://nodejs.org/en) HTTP server running on Unikraft.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 512M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME           KERNEL                      ARGS                              CREATED         STATUS   MEM   PORTS                   PLAT
+vigorous_loon  oci://unikraft.org/node:18  /usr/bin/node /usr/src/server.js  18 seconds ago  running  488M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `vigorous_loon`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm vigorous_loon
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 1024M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-nodejs18-base-distroless/src/server.js
+++ b/examples/httpserver-nodejs18-base-distroless/src/server.js
@@ -1,0 +1,16 @@
+const http = require('http');
+
+const server = http.createServer((req, resp) => {
+  resp.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  resp.write('Bye, World!\n');
+
+  resp.end();
+})
+
+server.listen(8080, "0.0.0.0", () => {
+  console.log(`Listening on :8080...`);
+});
+ 


### PR DESCRIPTION
## Description

Add a distroless variant of the `httpserver-nodejs18` example using the Unikraft `node:18` runtime and a minimal Debian-based Distroless root filesystem.

## Changes

- Add the `httpserver-nodejs18-base-distroless` example.
- Use `gcr.io/distroless/base-debian12` as the root filesystem base.
- Copy the Node.js runtime and required musl libraries from `node:18-alpine`.
- Add the Node.js HTTP server application listening on port `8080`.
- Add the `Kraftfile`, `Dockerfile`, source code, and README.
- Add a GitHub Actions workflow to build, scan, and test the example.
- Validate that the HTTP server starts successfully and returns the expected `Bye, World!` response.

## Testing

The example was tested successfully with KraftKit and QEMU.

The GitHub Actions workflow validates:

- The Unikernel builds successfully.
- The filesystem is scanned with Trivy.
- The Node.js 18 HTTP server starts successfully.
- The server is reachable on port `8080`.
- The expected `Bye, World!` response is returned.