### PR TITLE
feat(examples): Add Expressjs4.18 Node21 base distroless

### DIFF
--- a/.github/workflows/test-expressjs4.18-node21-base-distroless.yaml
+++ b/.github/workflows/test-expressjs4.18-node21-base-distroless.yaml
@@ -1,0 +1,86 @@
+name: Test ExpressJS 4.18 Node 21 Base Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/expressjs4.18-node21-base-distroless/**"
+      - ".github/workflows/test-expressjs4.18-node21-base-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/expressjs4.18-node21-base-distroless/**"
+      - ".github/workflows/test-expressjs4.18-node21-base-distroless.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+          awk -v f="kraft_${KRAFT_VERSION}_linux_amd64.tar.gz" '($2==f)||($2=="*"f){print}' "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/expressjs4.18-node21-base-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/expressjs4.18-node21-base-distroless
+        run: |
+          du -sh .unikraft/build/initramfs-x86_64.cpio
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/expressjs4.18-node21-base-distroless
+        run: docker build --pull -t expressjs-node21-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          image-ref: "expressjs-node21-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/expressjs4.18-node21-base-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run Unikernel in Background
+        working-directory: examples/expressjs4.18-node21-base-distroless
+        run: kraft run -d --rm -p 3000:3000 --plat qemu --arch x86_64 -M 1024M --name node-express-test .
+
+      - name: Test Network Connectivity
+        run: |
+          sleep 5
+          curl -s localhost:3000 | grep "Bye, World!"
+
+      - name: Cleanup
+        if: always()
+        run: kraft rm --force node-express-test || true

--- a/examples/expressjs4.18-node21-base-distroless/.dockerignore
+++ b/examples/expressjs4.18-node21-base-distroless/.dockerignore
@@ -1,0 +1,6 @@
+dist/
+node_modules/
+/.unikraft/
+/Dockerfile
+/Kraftfile
+/README.md

--- a/examples/expressjs4.18-node21-base-distroless/.gitignore
+++ b/examples/expressjs4.18-node21-base-distroless/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/.unikraft/

--- a/examples/expressjs4.18-node21-base-distroless/.trivyignore
+++ b/examples/expressjs4.18-node21-base-distroless/.trivyignore
@@ -1,0 +1,3 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30

--- a/examples/expressjs4.18-node21-base-distroless/Dockerfile
+++ b/examples/expressjs4.18-node21-base-distroless/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:21-alpine AS node
+
+WORKDIR /usr/src
+
+COPY . /usr/src/
+
+RUN npm install
+
+FROM cgr.dev/chainguard/node@sha256:105c8e7e503ea8f45553b9cc5aa0d24e80499bcc7c860dff54449e7c01d9be79
+
+COPY --from=node /usr/src/node_modules /usr/src/node_modules
+COPY --from=node /usr/src/app/index.js /usr/src/server.js

--- a/examples/expressjs4.18-node21-base-distroless/Kraftfile
+++ b/examples/expressjs4.18-node21-base-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: expressjs4.18-node21-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/expressjs4.18-node21-base-distroless/README.md
+++ b/examples/expressjs4.18-node21-base-distroless/README.md
@@ -1,0 +1,65 @@
+# Node 21 ExpressJS - Distroless
+
+This directory contains a Node 21 [`ExpressJS`](https://expressjs.com/) implementation running on Unikraft using using a securely pinned version of the `cgr.dev/chainguard/node` base image. This minimal environment lacks a shell and unnecessary system utilities, significantly reducing the attack surface while providing a natively PIE-compiled Node.js binary compatible with Unikraft.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 3000:3000 --plat qemu --arch x86_64 -M 1024M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+If the `-M` argument (memory allocation) is left out, it defaults to 64M. For this specific image, leaving it out will cause a boot failure (cpio archive extraction error) because the virtual machine runs out of memory while unpacking the filesystem in RAM. Explicitly setting it to `-M 1024M` provides enough memory and ensures the unikernel boots successfully.
+
+Once executed, it will open port `3000` and wait for connections.
+To test it, open a new terminal and you can use `curl`:
+
+```bash
+curl localhost:3000
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME          KERNEL                          ARGS                              CREATED        STATUS   MEM   PORTS                   PLAT
+clever_louis  oci://unikraft.org/base:latest  /usr/bin/node /usr/src/server.js  3 seconds ago  running  976M  0.0.0.0:3000->3000/tcp  qemu/x86_64
+```
+
+The instance name is `clever_louis`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm clever_louis
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run -p 3000:3000 --plat qemu --arch x86_64 -M 2048M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/expressjs4.18-node21-base-distroless/app/index.js
+++ b/examples/expressjs4.18-node21-base-distroless/app/index.js
@@ -1,0 +1,11 @@
+const express = require('express')
+const app = express()
+const port = 3000
+
+app.get('/', (req, res) => {
+  res.send('Bye, World!\n')
+})
+
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}`)
+})

--- a/examples/expressjs4.18-node21-base-distroless/package.json
+++ b/examples/expressjs4.18-node21-base-distroless/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
## Description

Added a Node.js 21 and Express.js 4.18 base example using the distroless container image `cgr.dev/chainguard/node`, which provides a minimal runtime environment. This example utilizes a multi-stage build, starting with `node:21-alpine` to install dependencies via `npm install`, and selectively copies the `node_modules` directory and the application entrypoint (`index.js` to `server.js`) into the final distroless image.

The `README.md` file contains instructions for building and running the example manually.

## Automated Testing

This PR contains a three-stage workflow to build and test this example via GitHub Actions:

1. Measuring the rootfs size (resulting in 176MB)
2. Scanning for vulnerabilities using Trivy
3. Validating the web application operations using `curl` and matching the "Bye, World!" message

## Note on Vulnerability Scanning:

Trivy scans are configured to pass by explicitly ignoring specific vulnerabilities via `.trivyignore`. `CVE-2026-14456` (libssl3) is ignored because it affects OpenSSL QUIC servers, a feature that this simple application does not implement or utilize (exception expires on 2026-11-30).