### PR TITLE
feat(examples): Add httpserver-python3.14-base-distroless example

### DIFF
--- a/.github/workflows/test-httpserver-python3.14-base-distroless.yml
+++ b/.github/workflows/test-httpserver-python3.14-base-distroless.yml
@@ -1,0 +1,117 @@
+name: Test Python3.14 HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-python3.14-base-distroless/**"
+      - ".github/workflows/test-httpserver-python3.14-base-distroless.yml"
+  pull_request:
+    paths:
+      - "examples/httpserver-python3.14-base-distroless/**"
+      - ".github/workflows/test-httpserver-python3.14-base-distroless.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Install KraftKit (Version Pinned & Verified)
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+
+          grep " kraft_${KRAFT_VERSION}_linux_amd64.tar.gz\$" "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-python3.14-base-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/httpserver-python3.14-base-distroless
+        run: |
+          set -euo pipefail
+
+          mapfile -t cpio_files < <(find .unikraft/build/ -type f -name "*.cpio")
+          if [ "${#cpio_files[@]}" -eq 0 ]; then
+            echo "No .cpio artifacts found under .unikraft/build/" >&2
+            exit 1
+          fi
+
+          du -h "${cpio_files[@]}"
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/httpserver-python3.14-base-distroless
+        run: docker build --pull -t httpserver-python3.14-base-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          scan-ref: "httpserver-python3.14-base-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/httpserver-python3.14-base-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run Unikernel in Background
+        working-directory: examples/httpserver-python3.14-base-distroless
+        run: kraft run -d --plat qemu --arch x86_64 -M 512M -p 8080:8080 --name httpserver-test .
+
+      - name: Test Network Connectivity
+        run: |
+          set -euo pipefail
+
+          for i in $(seq 1 15); do
+            if curl -s --max-time 2 http://127.0.0.1:8080/ | grep -q "Bye, World!"; then
+              echo "Server responded correctly."
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Server did not respond as expected within 15s" >&2
+          exit 1
+
+      - name: Dump Unikernel Logs on Failure
+        if: failure()
+        working-directory: examples/httpserver-python3.14-base-distroless
+        run: kraft ps -a; kraft logs httpserver-test || true
+
+      - name: Cleanup
+        if: always()
+        run: kraft rm --force httpserver-test || true

--- a/examples/httpserver-python3.14-base-distroless/.trivyignore
+++ b/examples/httpserver-python3.14-base-distroless/.trivyignore
@@ -1,0 +1,4 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30
+

--- a/examples/httpserver-python3.14-base-distroless/Dockerfile
+++ b/examples/httpserver-python3.14-base-distroless/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.14-trixie AS base
+
+RUN rm -rf /usr/local/lib/python3.14/ensurepip \
+           /usr/local/lib/python3.14/site-packages/*
+
+FROM gcr.io/distroless/cc-debian13@sha256:e86cf4f565c8eee2cbb2be073bb107dafb14734b53d5872da20fdf47418a02f4
+
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
+COPY --from=base /usr/local/bin/python3 /usr/local/bin/python3
+COPY --from=base /usr/local/lib/python3.14 /usr/local/lib/python3.14
+COPY --from=base /usr/local/lib/libpython3.14.so.1.0 /usr/local/lib/libpython3.14.so.1.0
+
+COPY ./server.py /server.py
+

--- a/examples/httpserver-python3.14-base-distroless/Kraftfile
+++ b/examples/httpserver-python3.14-base-distroless/Kraftfile
@@ -1,0 +1,10 @@
+spec: v0.6
+
+name: httpserver-python3.14-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/local/bin/python3", "/server.py"]
+

--- a/examples/httpserver-python3.14-base-distroless/README.md
+++ b/examples/httpserver-python3.14-base-distroless/README.md
@@ -1,0 +1,74 @@
+# Python HTTP Server - Distroless
+
+This directory contains a [Python](https://www.python.org/) HTTP server running on Unikraft that provides a simple response to each request.
+It utilizes a Distroless container image (`gcr.io/distroless/cc-debian13`) to provide a minimal, secure root filesystem containing only the required runtime dependencies.
+
+## Distroless Build
+
+For this example's needs, the chosen distroless image provides:
+
+- The dynamic linker `ld-linux-x86-64`
+- The libraries `libm`, `libpthread`, `libdl`, `libc`, `libutil` and `libz`
+
+The libraries related to Python are still manually copied on top of the base distroless image.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 512M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME            KERNEL                          ARGS                               CREATED         STATUS   MEM   PORTS                   PLAT
+reverent_karta  oci://unikraft.org/base:latest  /usr/local/bin/python3 /server.py  34 seconds ago  running  512M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `reverent_karta`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm reverent_karta
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 1024M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/examples/httpserver-python3.14-base-distroless/server.py
+++ b/examples/httpserver-python3.14-base-distroless/server.py
@@ -1,0 +1,35 @@
+import argparse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class MyServer(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write(bytes("Bye, World!\n", "utf-8"))
+
+
+def main(args):
+    server = HTTPServer((args.host, args.port), MyServer)
+
+    print("starting server at %s:%s" % (args.host, args.port))
+
+    try:
+        server.serve_forever()
+
+    except KeyboardInterrupt:
+        pass
+
+    print("server stopped")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8080)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())


### PR DESCRIPTION
## Description

Added a Python3.14 HTTP server example using the distroless container image `gcr.io/distroless/cc-debian13`, which is compatible with `trixie` and provides sufficient dependencies. This example is based on the [existing one](https://github.com/unikraft/catalog/tree/main/examples/httpserver-python3.14-base) in the catalog, enhancing the container build via distroless.

The `README.md` file contains instructions for building and running the example manually, as well as the list of dependencies that are covered by the chosen distroless image:

- The dynamic linker `ld-linux-x86-64`
- The libraries `libm`, `libpthread`, `libdl`, `libc`, `libutil` and `libz`

The libraries related to Python are still manually copied on top of the base distroless image (see `Dockerfile`).

## Automated Testing

The second commit of this PR contains a three-stage workflow to build and test this example via Github Actions:

1. Measuring the `rootfs` size (resulting in *93MB*)
2. Scanning for vulnerabilities using Trivy (one found, but not relevant, see `.trivyignore` for more)
3. Running in the background and testing connectivity using `curl`