### PR TITLE
feat(examples): Add httpserver-gcc13.2-distroless example

### DIFF
--- a/.github/workflows/test-httpserver-gcc13.2-distroless.yml
+++ b/.github/workflows/test-httpserver-gcc13.2-distroless.yml
@@ -1,0 +1,117 @@
+name: Test C13.2 HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-gcc13.2-distroless/**"
+      - ".github/workflows/test-httpserver-gcc13.2-distroless.yml"
+  pull_request:
+    paths:
+      - "examples/httpserver-gcc13.2-distroless/**"
+      - ".github/workflows/test-httpserver-gcc13.2-distroless.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Install KraftKit (Version Pinned & Verified)
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+
+          grep " kraft_${KRAFT_VERSION}_linux_amd64.tar.gz\$" "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-gcc13.2-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/httpserver-gcc13.2-distroless
+        run: |
+          set -euo pipefail
+
+          mapfile -t cpio_files < <(find .unikraft/build/ -type f -name "*.cpio")
+          if [ "${#cpio_files[@]}" -eq 0 ]; then
+            echo "No .cpio artifacts found under .unikraft/build/" >&2
+            exit 1
+          fi
+
+          du -h "${cpio_files[@]}"
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/httpserver-gcc13.2-distroless
+        run: docker build --pull -t httpserver-gcc13.2-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          scan-ref: "httpserver-gcc13.2-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/httpserver-gcc13.2-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run Unikernel in Background
+        working-directory: examples/httpserver-gcc13.2-distroless
+        run: kraft run -d --plat qemu --arch x86_64 -M 128M -p 8080:8080 --name httpserver-test .
+
+      - name: Test Network Connectivity
+        run: |
+          set -euo pipefail
+
+          for i in $(seq 1 15); do
+            if curl -s --max-time 2 http://127.0.0.1:8080 | grep -q "Bye, World!"; then
+              echo "Server responded correctly."
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Server did not respond as expected within 15s" >&2
+          exit 1
+
+      - name: Dump Unikernel Logs on Failure
+        if: failure()
+        working-directory: examples/httpserver-gcc13.2-distroless
+        run: kraft ps -a; kraft logs httpserver-test || true
+
+      - name: Cleanup
+        if: always()
+        run: kraft rm --force httpserver-test || true

--- a/examples/httpserver-gcc13.2-distroless/.trivyignore
+++ b/examples/httpserver-gcc13.2-distroless/.trivyignore
@@ -1,0 +1,4 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30
+

--- a/examples/httpserver-gcc13.2-distroless/Dockerfile
+++ b/examples/httpserver-gcc13.2-distroless/Dockerfile
@@ -1,0 +1,16 @@
+FROM gcc:13.2.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./http_server.c /src/http_server.c
+
+RUN set -xe; \
+    gcc \
+	-Wall -Wextra \
+	-fPIC -pie \
+	-o /http_server http_server.c
+
+FROM gcr.io/distroless/cc-debian12@sha256:e5d81ddde149641e2a9ba55be4545bc125c67de07508b03ba4c22e6eb0ded5aa
+
+COPY --from=build /http_server /http_server
+

--- a/examples/httpserver-gcc13.2-distroless/Kraftfile
+++ b/examples/httpserver-gcc13.2-distroless/Kraftfile
@@ -1,0 +1,10 @@
+spec: v0.6
+
+name: httpserver-gcc13.2-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/http_server"]
+

--- a/examples/httpserver-gcc13.2-distroless/README.md
+++ b/examples/httpserver-gcc13.2-distroless/README.md
@@ -1,0 +1,72 @@
+# C HTTP Web Server - Distroless
+
+This directory contains a C HTTP server running on Unikraft.
+It utilizes a Distroless container image (`gcr.io/distroless/cc-debian12`) to provide a minimal, secure root filesystem containing only the required runtime dependencies.
+
+## Distroless Build
+
+For this example's needs, the chosen distroless image provides:
+
+- The dynamic linker `ld-linux-x86-64`
+- The library `libc`
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 128M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME           KERNEL                          ARGS          CREATED        STATUS   MEM   PORTS                   PLAT
+elegant_tetra  oci://unikraft.org/base:latest  /http_server  9 seconds ago  running  128M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `elegant_tetra`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm elegant_tetra
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 256M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-gcc13.2-distroless/http_server.c
+++ b/examples/httpserver-gcc13.2-distroless/http_server.c
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2023, Unikraft GmbH and the Unikraft Authors.
+ */
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define LISTEN_PORT 8080
+static const char reply[] = "HTTP/1.1 200 OK\r\n"
+                            "Content-Type: text/html\r\n"
+                            "Content-Length: 12\r\n"
+                            "Connection: close\r\n"
+                            "\r\n"
+                            "Bye, World!\n";
+
+#define BUFLEN 2048
+static char recvbuf[BUFLEN];
+
+int main(int argc __attribute__((unused)),
+         char *argv[] __attribute__((unused))) {
+  int rc = 0;
+  int srv, client;
+  ssize_t n;
+  struct sockaddr_in srv_addr;
+
+  srv = socket(AF_INET, SOCK_STREAM, 0);
+  if (srv < 0) {
+    fprintf(stderr, "Failed to create socket: %d\n", errno);
+    goto out;
+  }
+
+  srv_addr.sin_family = AF_INET;
+  srv_addr.sin_addr.s_addr = INADDR_ANY;
+  srv_addr.sin_port = htons(LISTEN_PORT);
+
+  rc = bind(srv, (struct sockaddr *)&srv_addr, sizeof(srv_addr));
+  if (rc < 0) {
+    fprintf(stderr, "Failed to bind socket: %d\n", errno);
+    goto out;
+  }
+
+  /* Accept one simultaneous connection */
+  rc = listen(srv, 1);
+  if (rc < 0) {
+    fprintf(stderr, "Failed to listen on socket: %d\n", errno);
+    goto out;
+  }
+
+  printf("Listening on port %d...\n", LISTEN_PORT);
+  while (1) {
+    client = accept(srv, NULL, 0);
+    if (client < 0) {
+      fprintf(stderr, "Failed to accept incoming connection: %d\n", errno);
+      goto out;
+    }
+
+    /* Receive some bytes (ignore errors) */
+    read(client, recvbuf, BUFLEN);
+
+    /* Send reply */
+    n = write(client, reply, sizeof(reply) - 1);
+    if (n < 0)
+      fprintf(stderr, "Failed to send a reply\n");
+    else
+      printf("Sent a reply\n");
+
+    /* Close connection */
+    close(client);
+  }
+
+out:
+  return rc;
+}


### PR DESCRIPTION
## Description

Added a C13.2 HTTP server example using the distroless container image `gcr.io/distroless/cc-debian12`, which is compatible with `bookworm` and provides sufficient dependencies. This example is based on the [existing one](https://github.com/unikraft/catalog/tree/main/examples/httpserver-gcc13.2) in the catalog, enhancing the container build via distroless.

The `README.md` file contains instructions for building and running the example manually, as well as the list of dependencies that are covered by the chosen distroless image:

• The dynamic linker `ld-linux-x86-64`
• The library `libc`

## Automated Testing

The second commit of this PR contains a three-stage workflow to build and test this example via Github Actions:

1. Measuring the `rootfs` size (resulting in 23MB)
2. Scanning for vulnerabilities using Trivy (one found, but not relevant, see `.trivyignore` for more)
3. Running in the background and testing connectivity using `curl`
