### PR TITLE
feat(examples): Add expressjs4.18-node24-base-distroless example

### DIFF
--- a/.github/workflows/test-expressjs4.18-node24-base-distroless.yml
+++ b/.github/workflows/test-expressjs4.18-node24-base-distroless.yml
@@ -1,0 +1,117 @@
+name: Test Express.js4.18 Node24 Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/expressjs4.18-node24-base-distroless/**"
+      - ".github/workflows/test-expressjs4.18-node24-base-distroless.yml"
+  pull_request:
+    paths:
+      - "examples/expressjs4.18-node24-base-distroless/**"
+      - ".github/workflows/test-expressjs4.18-node24-base-distroless.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Install KraftKit (Version Pinned & Verified)
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+
+          grep " kraft_${KRAFT_VERSION}_linux_amd64.tar.gz\$" "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/expressjs4.18-node24-base-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/expressjs4.18-node24-base-distroless
+        run: |
+          set -euo pipefail
+
+          mapfile -t cpio_files < <(find .unikraft/build/ -type f -name "*.cpio")
+          if [ "${#cpio_files[@]}" -eq 0 ]; then
+            echo "No .cpio artifacts found under .unikraft/build/" >&2
+            exit 1
+          fi
+
+          du -h "${cpio_files[@]}"
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/expressjs4.18-node24-base-distroless
+        run: docker build --pull -t expressjs4.18-node24-base-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          scan-ref: "expressjs4.18-node24-base-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/expressjs4.18-node24-base-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run Unikernel in Background
+        working-directory: examples/expressjs4.18-node24-base-distroless
+        run: kraft run -d --plat qemu --arch x86_64 -M 1024M -p 3000:3000 --name express-test .
+
+      - name: Test Network Connectivity
+        run: |
+          set -euo pipefail
+
+          for i in $(seq 1 15); do
+            if curl -s --max-time 2 http://127.0.0.1:3000 | grep -q "Bye, World!"; then
+              echo "Server responded correctly."
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Server did not respond as expected within 15s" >&2
+          exit 1
+
+      - name: Dump Unikernel Logs on Failure
+        if: failure()
+        working-directory: examples/expressjs4.18-node24-base-distroless
+        run: kraft ps -a; kraft logs express-test || true
+
+      - name: Cleanup
+        if: always()
+        run: kraft rm --force express-test || true

--- a/examples/expressjs4.18-node24-base-distroless/.dockerignore
+++ b/examples/expressjs4.18-node24-base-distroless/.dockerignore
@@ -1,0 +1,6 @@
+dist/
+node_modules/
+/.unikraft/
+/Dockerfile
+/Kraftfile
+/README.md

--- a/examples/expressjs4.18-node24-base-distroless/.gitignore
+++ b/examples/expressjs4.18-node24-base-distroless/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/.unikraft/

--- a/examples/expressjs4.18-node24-base-distroless/.trivyignore
+++ b/examples/expressjs4.18-node24-base-distroless/.trivyignore
@@ -1,0 +1,4 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30
+

--- a/examples/expressjs4.18-node24-base-distroless/Dockerfile
+++ b/examples/expressjs4.18-node24-base-distroless/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:24-bookworm-slim AS build
+
+WORKDIR /usr/src
+
+COPY . /usr/src/
+
+RUN npm install
+
+FROM cgr.dev/chainguard/node@sha256:44e06504d7a99cfbf10a6ce9777c21fed05fa0f8ca29c24615b68683bf0184a1
+
+COPY --from=build /usr/src/node_modules /usr/src/node_modules
+COPY --from=build /usr/src/app/index.js /usr/src/server.js
+

--- a/examples/expressjs4.18-node24-base-distroless/Kraftfile
+++ b/examples/expressjs4.18-node24-base-distroless/Kraftfile
@@ -1,0 +1,10 @@
+spec: v0.6
+
+name: expressjs4.18-node24-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]
+

--- a/examples/expressjs4.18-node24-base-distroless/README.md
+++ b/examples/expressjs4.18-node24-base-distroless/README.md
@@ -1,0 +1,75 @@
+# Node 24 ExpressJS - Distroless
+
+This directory contains a Node 24 [`ExpressJS`](https://expressjs.com/) implementation running on Unikraft.
+It utilizes a Distroless container image (`cgr.dev/chainguard/node`) to provide a minimal, secure root filesystem containing only the required runtime dependencies.
+
+## Distroless Build
+
+For this example's needs, the chosen distroless image provides:
+
+- CA certificates (`ca-certificates`)
+- Timezone data (`tzdata`)
+- Standard `/tmp` and `/etc` directories
+- The dynamic linker `ld-musl-x86-64`
+- The libraries `libgcc_s` and `libstdc++`
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 3000:3000 --plat qemu --arch x86_64 -M 1024M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `3000` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:3000
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME             KERNEL                          ARGS                              CREATED         STATUS   MEM   PORTS                   PLAT
+great_missbaker  oci://unikraft.org/base:latest  /usr/bin/node /usr/src/server.js  22 seconds ago  running  1024M  0.0.0.0:3000->3000/tcp  qemu/x86_64
+```
+
+The instance name is `great_missbaker`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm great_missbaker
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run -p 3000:3000 --plat qemu --arch x86_64 -M 2048M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/expressjs4.18-node24-base-distroless/app/index.js
+++ b/examples/expressjs4.18-node24-base-distroless/app/index.js
@@ -1,0 +1,11 @@
+const express = require("express");
+const app = express();
+const port = 3000;
+
+app.get("/", (req, res) => {
+  res.send("Bye, World!\n");
+});
+
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}`);
+});

--- a/examples/expressjs4.18-node24-base-distroless/package.json
+++ b/examples/expressjs4.18-node24-base-distroless/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
## Description

Added an Express.js4.18 Node 24 server example using the distroless container image `cgr.dev/chainguard/node`, which is compatible with `bookworm-slim` and provides sufficient dependencies. This example is based on the [existing one](https://github.com/unikraft/catalog/tree/main/examples/expressjs4.18-node24-base) in the catalog, enhancing the container build via distroless.

The `README.md` file contains instructions for building and running the example manually, as well as the list of dependencies that are covered by the chosen distroless image:

• CA certificates (`ca-certificates`)
• Timezone data (`tzdata`)
• Standard `/tmp` and `/etc` directories
• The dynamic linker `ld-musl-x86-64`
• The libraries `libgcc_s` and `libstdc++`

## Automated Testing

The second commit of this PR contains a three-stage workflow to build and test this example via Github Actions:

1. Measuring the rootfs size (resulting in *176MB*)
2. Scanning for vulnerabilities using Trivy (one found, but not relevant, see `.trivyignore` for more)
3. Running in the background and testing connectivity using `curl`