### PR TITLE
feat(examples): Add http-response-cache-rust-distroless example

### DIFF
--- a/.github/workflows/test-http-response-cache-rust-distroless.yaml
+++ b/.github/workflows/test-http-response-cache-rust-distroless.yaml
@@ -1,0 +1,95 @@
+name: Test Rust HTTP Response Cache Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/http-response-cache-rust-distroless/**"
+      - ".github/workflows/test-http-response-cache-rust-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/http-response-cache-rust-distroless/**"
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        run: curl -sSfL https://get.kraftkit.sh | sudo DEBIAN_FRONTEND=noninteractive sh -s -- -y
+
+      - name: Build Unikernel
+        working-directory: examples/http-response-cache-rust-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/http-response-cache-rust-distroless
+        run: |
+          du -sh .unikraft/build/ || true
+          find .unikraft/build/ -type f -name "*.img" -exec du -h {} + || true
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          scan-ref: "examples/http-response-cache-rust-distroless"
+          format: "table"
+          exit-code: "0"
+          severity: "CRITICAL,HIGH"
+
+      - name: Build Docker Image
+        working-directory: examples/http-response-cache-rust-distroless
+        run: docker build -t http-response-cache-rust-distroless .
+
+      - name: Run Docker Container
+        run: |
+          docker run -d \
+            --name http-response-cache \
+            -p 8080:8080 \
+            http-response-cache-rust-distroless
+
+      - name: Validate HTTP Cache
+        run: |
+          for i in $(seq 1 30); do
+            if curl --silent --fail http://127.0.0.1:8080/hello > response-1.txt; then
+              break
+            fi
+            sleep 1
+          done
+
+          grep -q "CACHE MISS: Generated response for /hello" response-1.txt
+
+          curl --silent --fail \
+            http://127.0.0.1:8080/hello > response-2.txt
+
+          grep -q "CACHE HIT: Generated response for /hello" response-2.txt
+
+          curl --silent --fail \
+            http://127.0.0.1:8080/world > response-3.txt
+
+          grep -q "CACHE MISS: Generated response for /world" response-3.txt
+
+          curl --silent --fail \
+            http://127.0.0.1:8080/world > response-4.txt
+
+          grep -q "CACHE HIT: Generated response for /world" response-4.txt
+
+          STATUS=$(curl \
+            --silent \
+            --output post-response.txt \
+            --write-out "%{http_code}" \
+            --request POST \
+            http://127.0.0.1:8080/hello)
+
+          test "$STATUS" = "405"
+
+          grep -q "Method Not Allowed" post-response.txt
+
+          echo "HTTP response cache tests passed."
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f http-response-cache || true

--- a/examples/http-response-cache-rust-distroless/Dockerfile
+++ b/examples/http-response-cache-rust-distroless/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:1.89 AS builder
+
+WORKDIR /app
+
+COPY src/main.rs .
+
+RUN mkdir -p /out
+
+RUN rustc \
+    --edition=2021 \
+    -C opt-level=3 \
+    -C target-feature=+crt-static \
+    -o /out/http-response-cache \
+    main.rs
+
+FROM gcr.io/distroless/static-debian12
+
+COPY --from=builder /out/http-response-cache /usr/bin/http-response-cache
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/bin/http-response-cache"]

--- a/examples/http-response-cache-rust-distroless/Kraftfile
+++ b/examples/http-response-cache-rust-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: http-response-cache
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/http-response-cache"]

--- a/examples/http-response-cache-rust-distroless/README.md
+++ b/examples/http-response-cache-rust-distroless/README.md
@@ -1,0 +1,156 @@
+# HTTP Response Cache
+
+This directory contains a minimal HTTP response cache written in Rust and running on Unikraft.
+
+The application stores generated HTTP responses in an in-memory cache and returns the cached response for subsequent requests to the same path.
+
+The application is compiled into a statically linked executable and placed into a Distroless root filesystem.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Build and run the example with:
+
+```bash
+kraft run --rm --plat qemu --arch x86_64 -M 128M -p 8080:8080 .
+```
+
+The HTTP server listens on port `8080`.
+
+The `-p 8080:8080` option forwards port `8080` from the Unikraft instance to port `8080` on the host.
+
+### Test the Cache
+
+Send a request to the application:
+
+```bash
+curl http://localhost:8080/hello
+```
+
+The first request to `/hello` produces a cache miss:
+
+```text
+CACHE MISS: Generated response for /hello
+```
+
+Send the same request again:
+
+```bash
+curl http://localhost:8080/hello
+```
+
+The subsequent request produces a cache hit:
+
+```text
+CACHE HIT: Generated response for /hello
+```
+
+Different paths are cached independently. For example:
+
+```bash
+curl http://localhost:8080/world
+```
+
+produces:
+
+```text
+CACHE MISS: Generated response for /world
+```
+
+A subsequent request to the same path returns:
+
+```text
+CACHE HIT: Generated response for /world
+```
+
+Only `GET` requests are supported. Other HTTP methods return `405 Method Not Allowed`.
+
+For example:
+
+```bash
+curl -i -X POST http://localhost:8080/hello
+```
+
+returns:
+
+```text
+HTTP/1.1 405 Method Not Allowed
+```
+
+## Distroless Image
+
+The application is compiled in a separate Rust builder stage.
+
+The final root filesystem uses the Distroless static Debian 12 image:
+
+```dockerfile
+FROM gcr.io/distroless/static-debian12
+
+COPY --from=builder /out/http-response-cache /usr/bin/http-response-cache
+```
+
+The final image contains the application executable together with the minimal files provided by the Distroless base image.
+
+It does not contain a shell, package manager, Rust compiler, or other build-time tools.
+
+## Build
+
+The Rust application is compiled with release-oriented optimizations:
+
+```bash
+rustc \
+    --edition=2021 \
+    -C opt-level=3 \
+    -C target-feature=+crt-static \
+    -o /out/http-response-cache \
+    main.rs
+```
+
+The Docker image can be built directly with:
+
+```bash
+docker build -t http-response-cache-distroless .
+```
+
+## Unikraft Build
+
+To build the application image with Unikraft without starting it, run:
+
+```bash
+kraft build --plat qemu --arch x86_64 .
+```
+
+This builds the application root filesystem from the Dockerfile and prepares it to run as a Unikraft unikernel.
+
+## Inspect and Close
+
+To list information about the running Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+To close the Unikraft instance, press `Ctrl+c` in the terminal running `kraft run`.
+
+Alternatively, a running instance can be removed with:
+
+```bash
+kraft rm <instance-name>
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+
+Read more about how to start `kraft` without `sudo` at:
+
+https://unikraft.org/sudoless
+
+## Learn More
+
+* https://www.rust-lang.org/
+* https://unikraft.org/docs/cli/running
+* https://unikraft.org/guides/building-dockerfile-images-with-buildkit

--- a/examples/http-response-cache-rust-distroless/src/main.rs
+++ b/examples/http-response-cache-rust-distroless/src/main.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+
+fn handle_client(mut stream: TcpStream, cache: Arc<Mutex<HashMap<String, String>>>) {
+    let mut buffer = [0; 4096];
+
+    let Ok(size) = stream.read(&mut buffer) else {
+        return;
+    };
+
+    let request = String::from_utf8_lossy(&buffer[..size]);
+
+    let Some(request_line) = request.lines().next() else {
+        return;
+    };
+
+    let mut parts = request_line.split_whitespace();
+
+    let Some(method) = parts.next() else {
+        return;
+    };
+
+    let Some(path) = parts.next() else {
+        return;
+    };
+
+    if method != "GET" {
+        let response =
+            "HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 18\r\n\r\nMethod Not Allowed";
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
+    let mut cache = cache.lock().unwrap();
+
+    let body = if let Some(value) = cache.get(path) {
+        format!("CACHE HIT: {value}")
+    } else {
+        let value = format!("Generated response for {path}");
+        cache.insert(path.to_string(), value.clone());
+        format!("CACHE MISS: {value}")
+    };
+
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+
+    let _ = stream.write_all(response.as_bytes());
+}
+
+fn main() {
+    let listener = TcpListener::bind("0.0.0.0:8080").expect("failed to bind port 8080");
+
+    let cache = Arc::new(Mutex::new(HashMap::new()));
+
+    println!("HTTP response cache listening on port 8080");
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let cache = Arc::clone(&cache);
+
+                std::thread::spawn(move || {
+                    handle_client(stream, cache);
+                });
+            }
+            Err(error) => {
+                eprintln!("connection error: {error}");
+            }
+        }
+    }
+}


### PR DESCRIPTION

## Description

This PR adds a new Rust-based HTTP response cache example running with Unikraft and a Distroless `static-debian12` runtime.

The example implements a minimal HTTP server listening on port `8080` with an in-memory response cache. The first `GET` request to a path generates and stores a response, while subsequent requests to the same path return the cached response. Non-`GET` requests return HTTP `405 Method Not Allowed`.

### Included

- Minimal Rust HTTP server
- In-memory response cache using `HashMap`
- `CACHE MISS` / `CACHE HIT` behavior
- Support for multiple cached paths
- `405 Method Not Allowed` for unsupported methods
- Statically linked Rust binary using `crt-static`
- Distroless `static-debian12` runtime image
- Unikraft `Kraftfile`
- GitHub Actions workflow for automated validation

### CI Validation

The workflow validates:

- Unikraft build for QEMU/x86_64
- RootFS size
- Trivy vulnerability scan
- Distroless Docker image build
- HTTP cache miss behavior
- HTTP cache hit behavior
- Separate cache entries for different paths
- `POST` requests returning HTTP `405`
