### PR TITLE
feat(examples): Add httpserver-csharp9-native-base-distroless example

### DIFF
--- a/.github/workflows/test-httpserver-csharp9-native-base-distroless.yml
+++ b/.github/workflows/test-httpserver-csharp9-native-base-distroless.yml
@@ -1,0 +1,117 @@
+name: Test .NET9 C# HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-csharp9-native-base-distroless/**"
+      - ".github/workflows/test-httpserver-csharp9-native-base-distroless.yml"
+  pull_request:
+    paths:
+      - "examples/httpserver-csharp9-native-base-distroless/**"
+      - ".github/workflows/test-httpserver-csharp9-native-base-distroless.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Install KraftKit (Version Pinned & Verified)
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+
+          grep " kraft_${KRAFT_VERSION}_linux_amd64.tar.gz\$" "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-csharp9-native-base-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/httpserver-csharp9-native-base-distroless
+        run: |
+          set -euo pipefail
+
+          mapfile -t cpio_files < <(find .unikraft/build/ -type f -name "*.cpio")
+          if [ "${#cpio_files[@]}" -eq 0 ]; then
+            echo "No .cpio artifacts found under .unikraft/build/" >&2
+            exit 1
+          fi
+
+          du -h "${cpio_files[@]}"
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/httpserver-csharp9-native-base-distroless
+        run: docker build --pull -t httpserver-csharp9-native-base-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          scan-ref: "httpserver-csharp9-native-base-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/httpserver-csharp9-native-base-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run Unikernel in Background
+        working-directory: examples/httpserver-csharp9-native-base-distroless
+        run: kraft run -d --plat qemu --arch x86_64 -M 128M -p 8080:8080 --name httpserver-test .
+
+      - name: Test Network Connectivity
+        run: |
+          set -euo pipefail
+
+          for i in $(seq 1 15); do
+            if curl -s --max-time 2 http://127.0.0.1:8080 | grep -q "Bye, World!"; then
+              echo "Server responded correctly."
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Server did not respond as expected within 15s" >&2
+          exit 1
+
+      - name: Dump Unikernel Logs on Failure
+        if: failure()
+        working-directory: examples/httpserver-csharp9-native-base-distroless
+        run: kraft ps -a; kraft logs httpserver-test || true
+
+      - name: Cleanup
+        if: always()
+        run: kraft rm --force httpserver-test || true

--- a/examples/httpserver-csharp9-native-base-distroless/.dockerignore
+++ b/examples/httpserver-csharp9-native-base-distroless/.dockerignore
@@ -1,0 +1,1 @@
+./unikraft/

--- a/examples/httpserver-csharp9-native-base-distroless/.gitignore
+++ b/examples/httpserver-csharp9-native-base-distroless/.gitignore
@@ -1,0 +1,1 @@
+./unikraft/

--- a/examples/httpserver-csharp9-native-base-distroless/.trivyignore
+++ b/examples/httpserver-csharp9-native-base-distroless/.trivyignore
@@ -1,0 +1,4 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30
+

--- a/examples/httpserver-csharp9-native-base-distroless/Dockerfile
+++ b/examples/httpserver-csharp9-native-base-distroless/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS build
+
+RUN apt-get update && apt-get install -y clang zlib1g-dev
+
+WORKDIR /source
+
+COPY app.csproj .
+COPY Program.cs .
+
+RUN set -xe; \
+    dotnet publish \
+    -c Release \
+    -r linux-x64 \
+    -o /publish
+
+FROM gcr.io/distroless/cc-debian13@sha256:e86cf4f565c8eee2cbb2be073bb107dafb14734b53d5872da20fdf47418a02f4
+
+COPY --from=build /publish/app /app
+

--- a/examples/httpserver-csharp9-native-base-distroless/Kraftfile
+++ b/examples/httpserver-csharp9-native-base-distroless/Kraftfile
@@ -1,0 +1,10 @@
+spec: v0.6
+
+name: httpserver-csharp9-native-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/app"]
+

--- a/examples/httpserver-csharp9-native-base-distroless/Program.cs
+++ b/examples/httpserver-csharp9-native-base-distroless/Program.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+class Program
+{
+    static void Main()
+    {
+        int port = 8080;
+        TcpListener server = null;
+        try
+        {
+            server = new TcpListener(IPAddress.Any, port);
+            server.Start();
+            Console.WriteLine($"Server listening on port {port}...");
+
+            while (true)
+            {
+                using TcpClient client = server.AcceptTcpClient();
+
+                using NetworkStream stream = client.GetStream();
+
+                byte[] buffer = new byte[1024];
+                int bytesRead = stream.Read(buffer, 0, buffer.Length);
+
+                string request = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+                Console.WriteLine("Received Request:\n" + request.Split('\n')[0]);
+
+                string responseString;
+
+                if (request.StartsWith("GET / HTTP/"))
+                {
+                    string responseBody = "Bye, World!\n";
+                    responseString = $"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {responseBody.Length}\r\nConnection: close\r\n\r\n{responseBody}";
+                }
+                else
+                {
+                    string responseBody = "404 Not Found\n";
+                    responseString = $"HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: {responseBody.Length}\r\nConnection: close\r\n\r\n{responseBody}";
+                }
+
+                byte[] msg = Encoding.UTF8.GetBytes(responseString);
+                stream.Write(msg, 0, msg.Length);
+                client.Close();
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Exception: {0}", e);
+        }
+        finally
+        {
+            server?.Stop();
+        }
+    }
+}
+

--- a/examples/httpserver-csharp9-native-base-distroless/README.md
+++ b/examples/httpserver-csharp9-native-base-distroless/README.md
@@ -1,0 +1,74 @@
+# .NET9 C# Native AOT HTTP Web Server - Distroless
+
+This directory contains a C# [.NET 9 Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/) HTTP server running on Unikraft.
+It utilizes a Distroless container image (`gcr.io/distroless/cc-debian13`) to provide a minimal, secure root filesystem containing only the required runtime dependencies.
+
+## Distroless Build
+
+For this example's needs, the chosen distroless image provides:
+
+- The dynamic linker `ld-linux-x86-64`
+- The libraries `libc`, `libm`, `libgcc_s`, and `libstdc++`
+
+Additionally, by enabling `<InvariantGlobalization>true</InvariantGlobalization>` in the `app.csproj` file, the binary completely drops its dependency on the `libicu` libraries.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 128M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME          KERNEL                          ARGS  CREATED         STATUS   MEM   PORTS                   PLAT
+stoic_washoe  oci://unikraft.org/base:latest  /app  16 seconds ago  running  128M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `stoic_washoe`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm stoic_washoe
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run -p 8080:8080 --plat qemu --arch x86_64 -M 256M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-csharp9-native-base-distroless/app.csproj
+++ b/examples/httpserver-csharp9-native-base-distroless/app.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <OutputType>Exe</OutputType>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <OptimizationPreference>Size</OptimizationPreference>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>false</ConcurrentGarbageCollection>
+  </PropertyGroup>
+
+</Project>
+


### PR DESCRIPTION
## Description

Added a .NET9 Native AOT C# HTTP server example using the distroless container image `gcr.io/distroless/cc-debian13`, which is compatible with `bookworm-slim` and provides sufficient dependencies.

The `README.md` file contains instructions for building and running the example manually, as well as the list of dependencies that are covered by the chosen distroless image:

- The dynamic linker `ld-linux-x86-64`
- The libraries `libc`, `libm`, `libgcc_s`, and `libstdc++`

## Automated Testing

The second commit of this PR contains a three-stage workflow to build and test this example via Github Actions:

1. Measuring the `rootfs` size (resulting in *29MB*)
2. Scanning for vulnerabilities using Trivy (one found, but not relevant, see `.trivyignore` for more)
3. Running in the background and testing connectivity using `curl`