### PR TITLE
feat(examples): Add httpserver g++13.2 distroless

### DIFF
--- a/.github/workflows/test-httpserver-g++13.2-distroless.yaml
+++ b/.github/workflows/test-httpserver-g++13.2-distroless.yaml
@@ -1,0 +1,86 @@
+name: Test C++ 13.2 HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'examples/httpserver-g\+\+13.2-distroless/**'
+      - '.github/workflows/test-httpserver-g\+\+13.2-distroless.yaml'
+  pull_request:
+    paths:
+      - 'examples/httpserver-g\+\+13.2-distroless/**'
+      - '.github/workflows/test-httpserver-g\+\+13.2-distroless.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit (Version Pinned & Verified)
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+          awk -v f="kraft_${KRAFT_VERSION}_linux_amd64.tar.gz" '($2==f)||($2=="*"f){print}' "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-g++13.2-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/httpserver-g++13.2-distroless
+        run: |
+          du -sh .unikraft/build/initramfs-x86_64.cpio
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/httpserver-g++13.2-distroless
+        run: docker build --pull -t httpserver-gpp13.2-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          image-ref: "httpserver-gpp13.2-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/httpserver-g++13.2-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run Unikernel in Background
+        working-directory: examples/httpserver-g++13.2-distroless
+        run: kraft run -d --rm -p 8080:8080 --plat qemu --arch x86_64 -M 128M --name httpserver-test .
+
+      - name: Test Network Connectivity
+        run: |
+          sleep 5
+          curl -s localhost:8080 | grep "Bye, World!"
+
+      - name: Cleanup
+        if: always()
+        run: kraft rm --force httpserver-test || true

--- a/examples/httpserver-g++13.2-distroless/.trivyignore
+++ b/examples/httpserver-g++13.2-distroless/.trivyignore
@@ -1,0 +1,3 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30

--- a/examples/httpserver-g++13.2-distroless/Dockerfile
+++ b/examples/httpserver-g++13.2-distroless/Dockerfile
@@ -1,0 +1,16 @@
+FROM gcc:13.2.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./http_server.cpp /src/http_server.cpp
+
+RUN set -xe; \
+  g++ \
+  -Wall -Wextra \
+  -fPIC -pie \
+  -o /http_server http_server.cpp
+
+FROM gcr.io/distroless/cc-debian13@sha256:9b615fff20e1a4fad29c2b30562580b212c7dd5e2225236735cca0070ed11c78
+
+# C++ HTTP server
+COPY --from=build /http_server /http_server

--- a/examples/httpserver-g++13.2-distroless/Kraftfile
+++ b/examples/httpserver-g++13.2-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-g++13.2-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/http_server"]

--- a/examples/httpserver-g++13.2-distroless/README.md
+++ b/examples/httpserver-g++13.2-distroless/README.md
@@ -1,0 +1,65 @@
+# C++ HTTP Web Server - Distroless
+
+This directory contains a C++ HTTP server running on Unikraft using the `gcr.io/distroless/cc-debian13` base image. This minimal environment lacks a shell and unnecessary system utilities, significantly reducing the attack surface.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 128M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+If the `-M` argument (memory allocation) is left out, it defaults to 64M. For this specific image, leaving it out will cause a boot failure (cpio archive extraction error) because the virtual machine runs out of memory while unpacking the filesystem in RAM. Explicitly setting it to `-M 128M` provides enough memory and ensures the unikernel boots successfully.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, open a new terminal and use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME              KERNEL                          ARGS          CREATED        STATUS   MEM   PORTS                   PLAT
+priceless_travis  oci://unikraft.org/base:latest  /http_server  6 seconds ago  running  122M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `priceless_travis`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm priceless_travis
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 256M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-g++13.2-distroless/http_server.cpp
+++ b/examples/httpserver-g++13.2-distroless/http_server.cpp
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2023, Unikraft GmbH and the Unikraft Authors.
+ */
+
+#include <iostream>
+#include <cstring>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <errno.h>
+
+#define LISTEN_PORT 8080
+
+static std::string reply = "HTTP/1.1 200 OK\r\n" \
+			    "Content-Type: text/html\r\n" \
+			    "Content-Length: 14\r\n" \
+			    "Connection: close\r\n" \
+			    "\r\n" \
+			    "Bye, World!\n";
+
+#define BUFLEN 2048
+static char recvbuf[BUFLEN];
+
+int main(int argc __attribute__((unused)),
+	 char *argv[] __attribute__((unused)))
+{
+	int rc = 0;
+	int srv, client;
+	ssize_t n;
+	struct sockaddr_in srv_addr;
+
+	srv = socket(AF_INET, SOCK_STREAM, 0);
+	if (srv < 0) {
+		std::cerr << "Failed to create socket: " << errno << std::endl;
+		goto out;
+	}
+
+	srv_addr.sin_family = AF_INET;
+	srv_addr.sin_addr.s_addr = INADDR_ANY;
+	srv_addr.sin_port = htons(LISTEN_PORT);
+
+	rc = bind(srv, (struct sockaddr *) &srv_addr, sizeof(srv_addr));
+	if (rc < 0) {
+		std::cerr << "Failed to bind socket: " << errno << std::endl;
+		goto out;
+	}
+
+	/* Accept one simultaneous connection */
+	rc = listen(srv, 1);
+	if (rc < 0) {
+		std::cerr << "Failed to listen on socket: " << errno << std::endl;
+		goto out;
+	}
+
+	std::cout << "Listening on port " << LISTEN_PORT << std::endl;
+	while (1) {
+		client = accept(srv, NULL, 0);
+		if (client < 0) {
+			std::cerr << "Failed to accept incoming connection: " << errno << std::endl;
+			goto out;
+		}
+
+		/* Receive some bytes (ignore errors) */
+		read(client, recvbuf, BUFLEN);
+
+		/* Send reply */
+		n = write(client, reply.c_str(), reply.length());
+		if (n < 0)
+			std::cerr << "Failed to send reply" << std::endl;
+		else
+			std::cout << "Sent a reply" << std::endl;
+
+		/* Close connection */
+		close(client);
+	}
+
+out:
+	return rc;
+}


### PR DESCRIPTION
## Description

Added a C++ 13.2 HTTP Server base example using the distroless container image `gcr.io/distroless/cc-debian13`, which provides a minimal runtime environment. This example utilizes a multi-stage build, starting with `gcc:13.2.0-bookworm` to compile the C++ source code (`http_server.cpp`) with PIE support (`-fPIC -pie`), and selectively copies the compiled `/http_server` binary into the final distroless image.

The `README.md` file contains instructions for building and running the example manually.

## Automated Testing

This PR contains a three-stage workflow to build and test this example via GitHub Actions:

1. Measuring the rootfs size (resulting in 27MB)
2. Scanning for vulnerabilities using Trivy
3. Validating the web application operations using `curl` and matching the "Bye, World!" message

## Note on Vulnerability Scanning:

Trivy scans are configured to pass by explicitly ignoring specific vulnerabilities via `.trivyignore`. `CVE-2026-14456` (`libssl3`) is ignored because it affects OpenSSL QUIC servers, a feature that this simple application does not implement or utilize (exception expires on 2026-11-30).