### PR TITLE
feat(examples): Add httpserver Nodejs24 base distroless

### DIFF
--- a/.github/workflows/test-httpserver-nodejs24-base-distroless.yaml
+++ b/.github/workflows/test-httpserver-nodejs24-base-distroless.yaml
@@ -1,0 +1,85 @@
+name: Test httpserver-nodejs24-base Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-nodejs24-base-distroless/**"
+      - ".github/workflows/test-httpserver-nodejs24-base-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/httpserver-nodejs24-base-distroless/**"
+      - ".github/workflows/test-httpserver-nodejs24-base-distroless.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit (Version Pinned & Verified)
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+          awk -v f="kraft_${KRAFT_VERSION}_linux_amd64.tar.gz" '($2==f)||($2=="*"f){print}' "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-nodejs24-base-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/httpserver-nodejs24-base-distroless
+        run: |
+          du -sh .unikraft/build/initramfs-x86_64.cpio
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/httpserver-nodejs24-base-distroless
+        run: docker build --pull -t httpserver-nodejs24-base-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          image-ref: "httpserver-nodejs24-base-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run Unikernel in Background
+        working-directory: examples/httpserver-nodejs24-base-distroless
+        run: kraft run -d --rm -p 8080:8080 --plat qemu --arch x86_64 -M 1024M --name node24-test .
+
+      - name: Test Network Connectivity
+        run: |
+          sleep 5
+          curl -s localhost:8080 | grep "Bye, World!"
+
+      - name: Cleanup
+        if: always()
+        run: kraft rm --force node24-test || true

--- a/examples/httpserver-nodejs24-base-distroless/.dockerignore
+++ b/examples/httpserver-nodejs24-base-distroless/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-nodejs24-base-distroless/.gitignore
+++ b/examples/httpserver-nodejs24-base-distroless/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-nodejs24-base-distroless/Dockerfile
+++ b/examples/httpserver-nodejs24-base-distroless/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:24-alpine3.20 AS node
+
+RUN set -xe; \
+  mkdir -p /target/etc; \
+  mkdir -p /blank; \
+  apk --no-cache add \
+  ca-certificates \
+  tzdata \
+  ; \
+  update-ca-certificates; \
+  ln -sf ../usr/share/zoneinfo/Etc/UTC /target/etc/localtime; \
+  echo "Etc/UTC" > /target/etc/timezone;
+
+FROM cgr.dev/chainguard/node:latest
+
+# Node HTTP server
+COPY ./src /usr/src

--- a/examples/httpserver-nodejs24-base-distroless/Kraftfile
+++ b/examples/httpserver-nodejs24-base-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-nodejs24-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/examples/httpserver-nodejs24-base-distroless/README.md
+++ b/examples/httpserver-nodejs24-base-distroless/README.md
@@ -1,0 +1,64 @@
+# Node 24 Web Server - Distroless
+
+This directory contains a [Node](https://nodejs.org/en) web server running on Unikraft using the cgr.dev/chainguard/node:latest base image. This minimal environment lacks a shell and unnecessary system utilities, significantly reducing the attack surface.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 1024M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, you can use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME            KERNEL                          ARGS                              CREATED        STATUS   MEM   PORTS                   PLAT
+cool_snowflake  oci://unikraft.org/base:latest  /usr/bin/node /usr/src/server.js  3 seconds ago  running  976M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `cool_snowflake`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm cool_snowflake
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag, for example:
+
+```bash
+kraft run -p 8080:8080 --plat qemu --arch x86_64 -M 2048M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-nodejs24-base-distroless/src/server.js
+++ b/examples/httpserver-nodejs24-base-distroless/src/server.js
@@ -1,0 +1,15 @@
+const http = require('http');
+
+const server = http.createServer((req, resp) => {
+  resp.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+
+  resp.write('Bye, World!\n');
+
+  resp.end();
+})
+
+server.listen(8080, "0.0.0.0", () => {
+  console.log(`Listening on :8080...`);
+});


### PR DESCRIPTION
## Description

Added a Node.js 24 HTTP Server base example using the distroless container image `cgr.dev/chainguard/node:latest`, which provides a minimal runtime environment and a natively PIE-compiled Node.js binary compatible with Unikraft. This example utilizes a multi-stage build, starting with `node:24-alpine3.20` to prepare CA certificates and timezone configurations, and copies the application files into the final distroless image.

The `README.md` file contains instructions for building and running the example manually.

## Automated Testing

This PR contains a three-stage workflow to build and test this example via GitHub Actions:

1. Measuring the rootfs size (resulting in 173MB)
2. Scanning for vulnerabilities using Trivy
3. Validating the web application operations using `curl` and matching the "Bye, World!" message