### PR TITLE
feat(examples): Add httpserver Ruby3.2 base distroless

### DIFF
--- a/.github/workflows/test-httpserver-ruby3.2-base-distroless.yaml
+++ b/.github/workflows/test-httpserver-ruby3.2-base-distroless.yaml
@@ -1,0 +1,86 @@
+name: Test Ruby HTTP Server Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/httpserver-ruby3.2-base-distroless/**"
+      - ".github/workflows/test-httpserver-ruby3.2-base-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/httpserver-ruby3.2-base-distroless/**"
+      - ".github/workflows/test-httpserver-ruby3.2-base-distroless.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit (Version Pinned & Verified)
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+          awk -v f="kraft_${KRAFT_VERSION}_linux_amd64.tar.gz" '($2==f)||($2=="*"f){print}' "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/httpserver-ruby3.2-base-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/httpserver-ruby3.2-base-distroless
+        run: |
+          du -sh .unikraft/build/initramfs-x86_64.cpio
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/httpserver-ruby3.2-base-distroless
+        run: docker build --pull -t httpserver-ruby3.2-base-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          image-ref: "httpserver-ruby3.2-base-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/httpserver-ruby3.2-base-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run Unikernel in Background
+        working-directory: examples/httpserver-ruby3.2-base-distroless
+        run: kraft run -d --rm -p 8080:8080 --plat qemu --arch x86_64 -M 256M --name ruby-test .
+
+      - name: Test Network Connectivity
+        run: |
+          sleep 5
+          curl -s localhost:8080 | grep "Bye, World!"
+
+      - name: Cleanup
+        if: always()
+        run: kraft rm --force ruby-test || true

--- a/examples/httpserver-ruby3.2-base-distroless/.dockerignore
+++ b/examples/httpserver-ruby3.2-base-distroless/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-ruby3.2-base-distroless/.gitignore
+++ b/examples/httpserver-ruby3.2-base-distroless/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/examples/httpserver-ruby3.2-base-distroless/.trivyignore
+++ b/examples/httpserver-ruby3.2-base-distroless/.trivyignore
@@ -1,0 +1,15 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30
+
+# Ruby 3.2 Default Gems Vulnerabilities
+# These are bundled with the upstream ruby:3.2 image.
+# Safe to ignore as this minimal example only uses the 'socket' module.
+CVE-2026-41316
+CVE-2026-42257
+CVE-2026-42245
+CVE-2026-42246
+CVE-2026-42258
+CVE-2024-49761
+CVE-2025-61594
+CVE-2026-27820

--- a/examples/httpserver-ruby3.2-base-distroless/Dockerfile
+++ b/examples/httpserver-ruby3.2-base-distroless/Dockerfile
@@ -1,0 +1,18 @@
+FROM --platform=linux/x86_64 ruby:3.2.2-bookworm AS build
+
+FROM gcr.io/distroless/cc-debian12@sha256:e5d81ddde149641e2a9ba55be4545bc125c67de07508b03ba4c22e6eb0ded5aa
+
+# Ruby binary
+COPY --from=build /usr/local/bin/ruby /usr/bin/ruby
+
+# Ruby libraries
+COPY --from=build /usr/local/lib/ruby /usr/local/lib/ruby
+
+# System libraries
+COPY --from=build /usr/local/lib/libruby.so.3.2 /usr/local/lib/libruby.so.3.2
+COPY --from=build /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libgmp.so.10 /lib/x86_64-linux-gnu/libgmp.so.10
+COPY --from=build /lib/x86_64-linux-gnu/libcrypt.so.1 /lib/x86_64-linux-gnu/libcrypt.so.1
+
+# Simple Ruby HTTP server
+COPY ./server.rb /src/server.rb

--- a/examples/httpserver-ruby3.2-base-distroless/Kraftfile
+++ b/examples/httpserver-ruby3.2-base-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: httpserver-ruby3.2-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/ruby", "/src/server.rb"]

--- a/examples/httpserver-ruby3.2-base-distroless/README.md
+++ b/examples/httpserver-ruby3.2-base-distroless/README.md
@@ -1,0 +1,60 @@
+# Ruby Web Server - Distroless
+
+This directory contains a [`Ruby`](https://www.ruby-lang.org/en/) web server running on Unikraft using the gcr.io/distroless/cc-debian12 base image. This minimal environment lacks a shell and unnecessary system utilities, significantly reducing the attack surface.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 8080:8080 --plat qemu --arch x86_64 -M 256M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+If the `-M` argument (memory allocation) is left out, it defaults to 64M. For this specific image, leaving it out will cause a boot failure (e.g., `Failed to extract cpio archive`) because the virtual machine runs out of memory while unpacking the filesystem in RAM. Explicitly setting it to `-M 256M` provides enough memory and ensures the unikernel boots successfully.
+
+Once executed, it will open port `8080` and wait for connections.
+To test it, open a new terminal and use `curl`:
+
+```bash
+curl localhost:8080
+```
+
+You should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME             KERNEL                          ARGS                           CREATED         STATUS   MEM   PORTS                   PLAT
+friendly_ramu    oci://unikraft.org/base:latest  /usr/bin/ruby /src/server.rb   6 seconds ago   running  244M  0.0.0.0:8080->8080/tcp  qemu/x86_64
+```
+
+The instance name is `friendly_ramu`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm friendly_ramu
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/httpserver-ruby3.2-base-distroless/server.rb
+++ b/examples/httpserver-ruby3.2-base-distroless/server.rb
@@ -1,0 +1,20 @@
+# https://dev.to/leandronsp/web-basics-a-simple-http-server-in-ruby-2jj4
+
+require 'socket'
+
+socket = TCPServer.new(8080)
+
+loop do
+  client = socket.accept
+
+  request = client.gets
+
+  response = "HTTP/1.1 200 OK\r\n" \
+    "Content-type: text/html\r\n" \
+    "Connection: close\r\n" \
+    "\r\n" \
+    "Bye, World!"
+  client.puts(response)
+
+  client.close
+end


### PR DESCRIPTION
## Description

Added a Ruby 3.2 HTTP Server base example using the distroless container image `gcr.io/distroless/cc-debian12`, which provides a minimal runtime environment. This example utilizes a multi-stage build, starting with `ruby:3.2.2-bookworm` to extract the Ruby executable, its standard libraries, and necessary system shared libraries (`libruby.so.3.2`, `libz.so.1`, `libgmp.so.10`, `libcrypt.so.1`), copying them alongside the application entrypoint (`server.rb`) into the final distroless image.

The `README.md` file contains instructions for building and running the example manually.

## Automated Testing

This PR contains a three-stage workflow to build and test this example via GitHub Actions:

1. Measuring the rootfs size (resulting in 76MB)
2. Scanning for vulnerabilities using Trivy
3. Validating the web application operations using `curl` and matching the "Bye, World!" message

## Note on Vulnerability Scanning:

Trivy scans are configured to pass by explicitly ignoring specific vulnerabilities via `.trivyignore`. 
* `CVE-2026-14456` (`libssl3`) is ignored because it affects OpenSSL QUIC servers, a feature that this simple application does not implement or utilize (exception expires on 2026-11-30).
* Several Ruby 3.2 Default Gems Vulnerabilities (e.g., `CVE-2026-41316`, `CVE-2026-42257`, `CVE-2024-49761`) bundled with the upstream `ruby:3.2` image are ignored. This is safe as this minimal example only relies on the standard `socket` module.