### PR TITLE
feat(examples): Add helloworld Haskell9.14.1 base distroless

### DIFF
--- a/.github/workflows/test-helloworld-haskell9.14.1-base-distroless.yaml
+++ b/.github/workflows/test-helloworld-haskell9.14.1-base-distroless.yaml
@@ -1,0 +1,82 @@
+name: Test Haskell 9.14.1 Bye World Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/helloworld-haskell9.14.1-base-distroless/**"
+      - ".github/workflows/test-helloworld-haskell9.14.1-base-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/helloworld-haskell9.14.1-base-distroless/**"
+      - ".github/workflows/test-helloworld-haskell9.14.1-base-distroless.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+
+          awk -v f="kraft_${KRAFT_VERSION}_linux_amd64.tar.gz" '($2==f)||($2=="*"f){print}' "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/helloworld-haskell9.14.1-base-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/helloworld-haskell9.14.1-base-distroless
+        run: |
+          du -sh .unikraft/build/initramfs-x86_64.cpio
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/helloworld-haskell9.14.1-base-distroless
+        run: docker build --pull -t helloworld-haskell9.14.1-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          image-ref: "helloworld-haskell9.14.1-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/helloworld-haskell9.14.1-base-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run and Validate Output
+        working-directory: examples/helloworld-haskell9.14.1-base-distroless
+        run: |
+           set -euo pipefail
+           kraft run --rm --plat qemu --arch x86_64 -M 256M . | grep "Bye, World!"

--- a/examples/helloworld-haskell9.14.1-base-distroless/.trivyignore
+++ b/examples/helloworld-haskell9.14.1-base-distroless/.trivyignore
@@ -1,0 +1,3 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30

--- a/examples/helloworld-haskell9.14.1-base-distroless/Dockerfile
+++ b/examples/helloworld-haskell9.14.1-base-distroless/Dockerfile
@@ -1,0 +1,18 @@
+FROM haskell:9.14.1-slim-bookworm AS build
+WORKDIR /opt/app
+
+COPY Main.hs shim.c ./
+
+RUN ghc -O2 -dynamic -fPIC -pie Main.hs shim.c
+
+RUN nm -D Main | grep clock_gettime
+
+RUN mkdir -p /deps && \
+  ldd Main | grep "=> /" | awk '{print $3}' | \
+  grep -Ev '/(libc|libm|libpthread|libdl|librt|libresolv|libutil|libcrypt|libgcc_s|libstdc\+\+|libssl|libcrypto)[.\-]' | \
+  xargs -I '{}' cp --parents '{}' /deps/
+
+FROM gcr.io/distroless/cc-debian12@sha256:e5d81ddde149641e2a9ba55be4545bc125c67de07508b03ba4c22e6eb0ded5aa
+
+COPY --from=build /deps/ /
+COPY --from=build /opt/app/Main /app/Main

--- a/examples/helloworld-haskell9.14.1-base-distroless/Kraftfile
+++ b/examples/helloworld-haskell9.14.1-base-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: helloworld-haskell9.14.1-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/app/Main"]

--- a/examples/helloworld-haskell9.14.1-base-distroless/Main.hs
+++ b/examples/helloworld-haskell9.14.1-base-distroless/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Bye, World!"

--- a/examples/helloworld-haskell9.14.1-base-distroless/README.md
+++ b/examples/helloworld-haskell9.14.1-base-distroless/README.md
@@ -1,0 +1,53 @@
+# Haskell 9.14.1 "Bye, World!" - Distroless
+
+This directory contains a Haskell-based "Bye, World!" example running on Unikraft using the `gcr.io/distroless/cc-debian12` base image. This specific image provides a minimal runtime environment optimized for dynamically linked applications. To ensure compatibility with Unikraft's POSIX implementation, a minimal C shim is linked to intercept unsupported `clock_gettime` calls made by the Haskell Runtime System (RTS). The final image contains only the necessary dependencies (like `libgmp` and `libffi`), completely stripping away the shell and unnecessary system utilities to reduce the attack surface.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm --plat qemu --arch x86_64 -M 256M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+If the `-M` argument (memory allocation) is left out, it defaults to 64M. For this specific image, leaving it out will cause a boot failure (cpio archive extraction error) because the virtual machine runs out of memory while unpacking the filesystem in RAM. Explicitly setting it to `-M 256M` provides enough memory and ensures the unikernel boots successfully.
+
+Once executed, you should see a "Bye, World!" message.
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME            KERNEL                          ARGS       CREATED  STATUS   MEM   PORTS  PLAT
+hungry_kokomo   oci://unikraft.org/base:latest  /app/Main  now      running  244M         qemu/x86_64
+```
+
+The instance name is `hungry_kokomo`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm hungry_kokomo
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/helloworld-haskell9.14.1-base-distroless/shim.c
+++ b/examples/helloworld-haskell9.14.1-base-distroless/shim.c
@@ -1,0 +1,9 @@
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+int clock_gettime(clockid_t clock_id, struct timespec *tp) {
+  if (clock_id == 2 || clock_id == 3)
+    clock_id = 1; /* CPUTIME -> MONOTONIC */
+  return syscall(SYS_clock_gettime, clock_id, tp);
+}


### PR DESCRIPTION
## Description

Added a Haskell 9.14.1 base example using the distroless container image `gcr.io/distroless/cc-debian12`, which provides a minimal runtime environment. This example utilizes a multi-stage build, starting with `haskell:9.14.1-slim-bookworm` to compile the Haskell source code (`Main.hs`) and a C shim with PIE support (`-dynamic -fPIC -pie`). It dynamically resolves and selectively copies the necessary shared dependencies (filtering out standard system libraries already provided or unneeded) alongside the compiled `/app/Main` binary into the final distroless image.

The `README.md` file contains instructions for building and running the example manually.

## Automated Testing

This PR contains a three-stage workflow to build and test this example via GitHub Actions:

1. Measuring the rootfs size (resulting in 46MB)
2. Scanning for vulnerabilities using Trivy
3. Validating the execution output by running the unikernel and matching the "Bye, World!" message

## Note on Vulnerability Scanning:

Trivy scans are configured to pass by explicitly ignoring specific vulnerabilities via `.trivyignore`. `CVE-2026-14456` (`libssl3`) is ignored because it affects OpenSSL QUIC servers, a feature that this simple application does not implement or utilize (exception expires on 2026-11-30).