### PR TITLE
feat(examples): Add jwt Authenticator Node22 base distroless

### DIFF
--- a/.github/workflows/test-jwt-authenticator-node22-base-distroless.yaml
+++ b/.github/workflows/test-jwt-authenticator-node22-base-distroless.yaml
@@ -1,0 +1,90 @@
+name: Test JWT Authenticator Base Distroless
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "examples/jwt-authenticator-node22-base-distroless/**"
+      - ".github/workflows/test-jwt-authenticator-node22-base-distroless.yaml"
+  pull_request:
+    paths:
+      - "examples/jwt-authenticator-node22-base-distroless/**"
+      - ".github/workflows/test-jwt-authenticator-node22-base-distroless.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-benchmark-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install KraftKit
+        env:
+          KRAFT_VERSION: "0.12.15"
+        run: |
+          set -euo pipefail
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          wget -q "https://github.com/unikraft/kraftkit/releases/download/v${KRAFT_VERSION}/kraftkit_${KRAFT_VERSION}_checksums.txt"
+          awk -v f="kraft_${KRAFT_VERSION}_linux_amd64.tar.gz" '($2==f)||($2=="*"f){print}' "kraftkit_${KRAFT_VERSION}_checksums.txt" | sha256sum -c -
+          tar -xzf "kraft_${KRAFT_VERSION}_linux_amd64.tar.gz"
+          chmod +x kraft
+          sudo install -o root -g root -m 0755 kraft /usr/local/bin/kraft
+          kraft version
+
+      - name: Build Unikernel
+        working-directory: examples/jwt-authenticator-node22-base-distroless
+        run: kraft build --plat qemu --arch x86_64 .
+
+      - name: Measure RootFS Size
+        working-directory: examples/jwt-authenticator-node22-base-distroless
+        run: |
+          du -sh .unikraft/build/initramfs-x86_64.cpio
+
+      - name: Build Distroless rootfs for Trivy
+        working-directory: examples/jwt-authenticator-node22-base-distroless
+        run: docker build --pull -t jwt-authenticator-distroless:ci .
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: "image"
+          image-ref: "jwt-authenticator-distroless:ci"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          trivyignores: "examples/jwt-authenticator-node22-base-distroless/.trivyignore"
+
+      - name: Install QEMU and Grant Permissions
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+          if [ -e /dev/kvm ]; then
+            sudo chown "$(id -u):$(id -g)" /dev/kvm
+            sudo chmod 660 /dev/kvm
+          fi
+
+      - name: Run Unikernel in Background
+        working-directory: examples/jwt-authenticator-node22-base-distroless
+        run: kraft run -d --rm -p 3000:3000 --plat qemu --arch x86_64 -M 1024M --name jwt-test .
+
+      - name: Test Network Connectivity and JWT Auth
+        working-directory: examples/jwt-authenticator-node22-base-distroless
+        run: |
+          sleep 5
+          curl -s http://localhost:3000/health | grep "ok"
+          npm install
+          TOKEN=$(node generate.js)
+          curl -s -H "Authorization: Bearer $TOKEN" http://localhost:3000/protected/me | grep "test-user"
+
+      - name: Cleanup
+        if: always()
+        run: kraft rm --force jwt-test || true

--- a/examples/jwt-authenticator-node22-base-distroless/.gitignore
+++ b/examples/jwt-authenticator-node22-base-distroless/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/examples/jwt-authenticator-node22-base-distroless/.trivyignore
+++ b/examples/jwt-authenticator-node22-base-distroless/.trivyignore
@@ -1,0 +1,3 @@
+# Pending upstream Debian fix for libssl3 DoS
+# This example isn't concerned with OpenSSL QUIC servers
+CVE-2026-14456 exp:2026-11-30

--- a/examples/jwt-authenticator-node22-base-distroless/Dockerfile
+++ b/examples/jwt-authenticator-node22-base-distroless/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+
+RUN npm ci --omit=dev 
+
+COPY index.js .
+
+FROM cgr.dev/chainguard/node@sha256:198c07af382e29f21e4f50b39921644599ee5d12bb92397bf7fb624a7a39801b
+
+WORKDIR /app
+
+COPY --from=build /app /app

--- a/examples/jwt-authenticator-node22-base-distroless/Kraftfile
+++ b/examples/jwt-authenticator-node22-base-distroless/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: jwt-authenticator-node21-base-distroless
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "--max-old-space-size=64", "/app/index.js"]

--- a/examples/jwt-authenticator-node22-base-distroless/README.md
+++ b/examples/jwt-authenticator-node22-base-distroless/README.md
@@ -1,0 +1,81 @@
+# Node 22 JWT Authenticator - Chainguard Distroless
+
+This directory contains a Node 22 JWT Gatekeeper implementation using [`Hono`](https://hono.dev/) and [`jose`](https://github.com/panva/jose) running on Unikraft. It uses a securely pinned version of the `cgr.dev/chainguard/node` base image. This minimal environment lacks a shell and unnecessary system utilities, significantly reducing the attack surface while providing a natively PIE-compiled Node.js binary compatible with Unikraft.
+
+## Set Up
+
+To run this example, [install Unikraft's companion command-line toolchain `kraft`](https://unikraft.org/docs/cli), clone this repository and `cd` into this directory.
+
+## Run and Use
+
+Use `kraft` to run the image and start a Unikraft instance:
+
+```bash
+kraft run --rm -p 3000:3000 --plat qemu --arch x86_64 -M 1024M .
+```
+
+If the `--plat` argument is left out, it defaults to `qemu`.
+
+If the `--arch` argument is left out, it defaults to your system's CPU architecture.
+
+If the `-M` argument (memory allocation) is left out, it defaults to 64M. Explicitly setting it to `-M 1024M` provides enough memory for the V8 engine startup and ensures the unikernel boots successfully.
+
+Once executed, it will open port `3000` and wait for connections.
+
+Test the public health endpoint:
+
+```bash
+curl http://localhost:3000/health
+```
+
+To test the protected endpoint, you need a valid JWT token. The application defaults to the secret `change-me-in-production`, which can be overridden in production using the `JWT_SECRET` environment variable.
+
+Install the local dependencies to use the generation script:
+
+```bash
+npm install
+node generate.js
+```
+
+Use the generated token to access the protected route:
+
+```bash
+curl -i -H "Authorization: Bearer <TOKEN>" http://localhost:3000/protected/me
+```
+
+## Inspect and Close
+
+To list information about the Unikraft instance, use:
+
+```bash
+kraft ps
+```
+
+```text
+NAME                KERNEL                          ARGS                                     CREATED        STATUS   MEM   PORTS                   PLAT
+busy_pocketswarhol  oci://unikraft.org/base:latest  /usr/bin/node --max-old-space-size=6...  4 seconds ago  running  976M  0.0.0.0:3000->3000/tcp  qemu/x86_64
+```
+
+The instance name is `busy_pocketswarhol`.
+To close the Unikraft instance, close the `kraft` process (e.g., via `Ctrl+c`) or run:
+
+```bash
+kraft rm busy_pocketswarhol
+```
+
+Note that depending on how you modify this example your instance **may** need more memory to run.
+To do so, use the `kraft run`'s `-M` flag:
+
+```bash
+kraft run -p 3000:3000 --plat qemu --arch x86_64 -M 2048M .
+```
+
+## `kraft` and `sudo`
+
+Mixing invocations of `kraft` and `sudo` can lead to unexpected behavior.
+Read more about how to start `kraft` without `sudo` at [https://unikraft.org/sudoless](https://unikraft.org/sudoless).
+
+## Learn More
+
+- [How to run unikernels locally](https://unikraft.org/docs/cli/running)
+- [Building `Dockerfile` Images with `BuildKit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/examples/jwt-authenticator-node22-base-distroless/generate.js
+++ b/examples/jwt-authenticator-node22-base-distroless/generate.js
@@ -1,0 +1,8 @@
+import { SignJWT } from 'jose'
+
+const secret = new TextEncoder().encode('change-me-in-production')
+const jwt = await new SignJWT({ user: 'test-user', role: 'admin' })
+  .setProtectedHeader({ alg: 'HS256' })
+  .sign(secret)
+
+console.log(jwt)

--- a/examples/jwt-authenticator-node22-base-distroless/index.js
+++ b/examples/jwt-authenticator-node22-base-distroless/index.js
@@ -1,0 +1,26 @@
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+import { jwtVerify } from 'jose'
+
+const app = new Hono()
+const secret = new TextEncoder().encode(process.env.JWT_SECRET || 'change-me-in-production')
+
+app.get('/health', (c) => c.text('ok'))
+
+app.use('/protected/*', async (c, next) => {
+  const auth = c.req.header('Authorization')
+  if (!auth?.startsWith('Bearer ')) {
+    return c.json({ error: 'missing token' }, 401)
+  }
+  try {
+    const { payload } = await jwtVerify(auth.slice(7), secret)
+    c.set('user', payload)
+    await next()
+  } catch {
+    return c.json({ error: 'invalid token' }, 401)
+  }
+})
+
+app.get('/protected/me', (c) => c.json({ user: c.get('user') }))
+
+serve({ fetch: app.fetch, port: 3000 })

--- a/examples/jwt-authenticator-node22-base-distroless/package-lock.json
+++ b/examples/jwt-authenticator-node22-base-distroless/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "jwt-authenticator",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jwt-authenticator",
+      "version": "1.0.0",
+      "dependencies": {
+        "@hono/node-server": "^1.13.0",
+        "hono": "^4.6.0",
+        "jose": "^5.9.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    }
+  }
+}

--- a/examples/jwt-authenticator-node22-base-distroless/package.json
+++ b/examples/jwt-authenticator-node22-base-distroless/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "jwt-authenticator",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "hono": "^4.6.0",
+    "@hono/node-server": "^1.13.0",
+    "jose": "^5.9.0"
+  }
+}


### PR DESCRIPTION
## Description

Added a Node.js 22 JWT Authenticator base example using the distroless container image `cgr.dev/chainguard/node`, which provides a minimal runtime environment. This example utilizes a multi-stage build, starting with `node:22-alpine` to install production dependencies (`npm ci --omit=dev`), and selectively copies the application files into the final distroless image.

The `README.md` file contains instructions for building and running the example manually.

## Automated Testing

This PR contains a three-stage workflow to build and test this example via GitHub Actions:

1. Measuring the rootfs size (resulting in 173MB)
2. Scanning for vulnerabilities using Trivy
3. Validating the web application operations using `curl` to check the `/health` endpoint and verifying JWT authentication on the `/protected/me` endpoint

## Note on Vulnerability Scanning:

Trivy scans are configured to pass by explicitly ignoring specific vulnerabilities via `.trivyignore`. `CVE-2026-14456` (`libssl3`) is ignored because it affects OpenSSL QUIC servers, a feature that this simple application does not implement or utilize (exception expires on 2026-11-30).